### PR TITLE
Feat/#18 장소 세부 조회 페이지 구현

### DIFF
--- a/src/app/(main)/(places)/places/[id]/page.tsx
+++ b/src/app/(main)/(places)/places/[id]/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import {
+  mockPlaceDetail,
+  PlaceBasicInfo,
+  PlaceMenu,
+  PlaceOpenHours,
+} from '@/features/place';
+import { Header } from '@/shared/components';
+
+export default function PlaceDetailPage() {
+  const router = useRouter();
+  // TODO: API 연동 시 실제 데이터로 교체
+  const place = mockPlaceDetail;
+
+  return (
+    <div className="flex h-screen flex-col">
+      <Header showBackButton onBackClick={() => router.back()} />
+      <div className="flex-1 overflow-y-auto pb-16">
+        <div className="container mx-auto mb-4 px-4 py-5">
+          <PlaceBasicInfo placeBasicInfo={place} />
+          <PlaceOpenHours openHours={place.opening_hours} />
+          <PlaceMenu menu={place.menu} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -130,6 +130,25 @@ body {
   display: none; /* Chrome, Safari, Opera */
 }
 
+/* 스크롤바 스타일 */
+::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #b6b6b6;
+  border-radius: 2px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #d1d5db;
+}
+
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/src/features/place/components/index.ts
+++ b/src/features/place/components/index.ts
@@ -5,3 +5,6 @@ export * from './keyword-list';
 export * from './place-bottom-sheet';
 export * from './search-result-bar';
 export * from './place-list';
+export * from './place-menu';
+export * from './place-open-hours';
+export * from './place-basic-info';

--- a/src/features/place/components/place-basic-info/PlaceBasicInfo.tsx
+++ b/src/features/place/components/place-basic-info/PlaceBasicInfo.tsx
@@ -1,0 +1,37 @@
+import { PlaceDetail } from '../../types';
+
+export interface PlaceBasicInfoProps {
+  placeBasicInfo: Omit<PlaceDetail, 'menu' | 'opening_hours'>;
+}
+
+export function PlaceBasicInfo({ placeBasicInfo }: PlaceBasicInfoProps) {
+  const { thumbnail, name, address, phone, keywords, description } =
+    placeBasicInfo;
+  return (
+    <>
+      <div className="relative mb-6 aspect-square w-full overflow-hidden rounded-lg">
+        <img
+          src={thumbnail}
+          alt={name}
+          className="h-full w-full object-cover"
+        />
+      </div>
+      <h1 className="heading-1 mb-4">{name}</h1>
+      <div className="mb-6">
+        <p className="body-text mb-2 text-gray-600">{address}</p>
+        <p className="body-text mb-2 text-gray-600">{phone}</p>
+        <div className="mb-4 flex gap-2">
+          {keywords.map((keyword) => (
+            <span
+              key={keyword}
+              className="caption rounded-full bg-gray-100 px-3 py-1 text-gray-800"
+            >
+              {keyword}
+            </span>
+          ))}
+        </div>
+        <p className="body-text text-gray-700">{description}</p>
+      </div>
+    </>
+  );
+}

--- a/src/features/place/components/place-basic-info/index.ts
+++ b/src/features/place/components/place-basic-info/index.ts
@@ -1,0 +1,1 @@
+export * from './PlaceBasicInfo';

--- a/src/features/place/components/place-menu/PlaceMenu.tsx
+++ b/src/features/place/components/place-menu/PlaceMenu.tsx
@@ -1,0 +1,23 @@
+import { Menu } from '../../types';
+
+interface PlaceMenuProps {
+  menu: Menu[];
+}
+
+export function PlaceMenu({ menu }: PlaceMenuProps) {
+  return (
+    <div>
+      <h2 className="heading-2 mb-3">메뉴</h2>
+      <div className="space-y-3">
+        {menu.map((item) => (
+          <div key={item.name} className="flex items-center justify-between">
+            <span className="body-text text-gray-800">{item.name}</span>
+            <span className="body-text text-gray-600">
+              {item.price.toLocaleString()}원
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/place/components/place-menu/index.ts
+++ b/src/features/place/components/place-menu/index.ts
@@ -1,0 +1,1 @@
+export * from './PlaceMenu';

--- a/src/features/place/components/place-open-hours/PlaceOpenHours.tsx
+++ b/src/features/place/components/place-open-hours/PlaceOpenHours.tsx
@@ -1,0 +1,36 @@
+import { OpenHours } from '../../types';
+
+export interface PlaceOpenHoursProps {
+  openHours: OpenHours;
+}
+
+export function PlaceOpenHours({ openHours }: PlaceOpenHoursProps) {
+  return (
+    <div className="mb-6">
+      <h2 className="heading-2 mb-3">영업 시간</h2>
+      <p className="body-text mb-2 font-medium text-green-600">
+        {openHours.status}
+      </p>
+      <div className="space-y-2">
+        {openHours.schedules.map((schedule) => (
+          <div key={schedule.day} className="flex justify-between">
+            <span className="body-text text-gray-600">
+              {schedule.day === 'mon' && '월요일'}
+              {schedule.day === 'tue' && '화요일'}
+              {schedule.day === 'wed' && '수요일'}
+              {schedule.day === 'thu' && '목요일'}
+              {schedule.day === 'fri' && '금요일'}
+              {schedule.day === 'sat' && '토요일'}
+              {schedule.day === 'sun' && '일요일'}
+            </span>
+            {schedule.hours ? (
+              <span className="body-text text-gray-800">{schedule.hours}</span>
+            ) : (
+              <span className="body-text text-red-500">{schedule.note}</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/place/components/place-open-hours/index.ts
+++ b/src/features/place/components/place-open-hours/index.ts
@@ -1,0 +1,1 @@
+export * from './PlaceOpenHours';

--- a/src/features/place/index.ts
+++ b/src/features/place/index.ts
@@ -1,2 +1,3 @@
-export * from './hooks';
 export * from './components';
+export * from './hooks';
+export * from './types';

--- a/src/features/place/types/index.ts
+++ b/src/features/place/types/index.ts
@@ -1,0 +1,1 @@
+export * from './place';

--- a/src/features/place/types/place.ts
+++ b/src/features/place/types/place.ts
@@ -1,0 +1,106 @@
+export interface PlaceDetail {
+  id: number;
+  name: string;
+  address: string;
+  thumbnail: string;
+  location: {
+    coordinates: [number, number];
+    type: string;
+  };
+  keywords: string[];
+  description: string;
+  phone: string;
+  menu: Menu[];
+  opening_hours: OpenHours;
+}
+
+export interface OpenHours {
+  status: string;
+  schedules: {
+    day: string;
+    hours: string | null;
+    note: string | null;
+  }[];
+}
+export interface Menu {
+  name: string;
+  price: number;
+}
+
+export const mockPlaceDetail: PlaceDetail = {
+  id: 1,
+  name: '해목 논현점',
+  address: '서울 강남구 선릉로 145길 14',
+  thumbnail:
+    'https://images.unsplash.com/photo-1563245372-f21724e3856d?q=80&w=1000&auto=format&fit=crop',
+  location: {
+    coordinates: [126.9804, 37.5231],
+    type: 'Point',
+  },
+  keywords: ['포장', '주차', '밀실'],
+  description:
+    '다양한 맛과 특별한 장어의 만남. 다양한 맛과 특별한 장어의 만남. 다양한 맛과 특별한 장어의 만남. 다양한 맛과 특별한 장어의 만남.',
+  phone: '0507-0505-0607',
+  menu: [
+    {
+      name: '장어구이',
+      price: 25000,
+    },
+    {
+      name: '소주',
+      price: 5000,
+    },
+    {
+      name: '맥주',
+      price: 5000,
+    },
+    {
+      name: '장어찜',
+      price: 35000,
+    },
+    {
+      name: '미꾸라지탕',
+      price: 15000,
+    },
+  ],
+  opening_hours: {
+    status: '영업 중',
+    schedules: [
+      {
+        day: 'mon',
+        hours: '08:00~17:00',
+        note: null,
+      },
+      {
+        day: 'tue',
+        hours: '08:00~17:00',
+        note: null,
+      },
+      {
+        day: 'wed',
+        hours: '08:00~17:00',
+        note: null,
+      },
+      {
+        day: 'thu',
+        hours: '08:00~17:00',
+        note: null,
+      },
+      {
+        day: 'fri',
+        hours: '08:00~17:00',
+        note: null,
+      },
+      {
+        day: 'sat',
+        hours: null,
+        note: '정기휴무 (매주 토요일)',
+      },
+      {
+        day: 'sun',
+        hours: null,
+        note: '정기휴무 (매주 일요일)',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## 📝 PR 개요

장소 상세 페이지(`places/[id]`)를 구현했습니다. 장소의 기본 정보, 영업 시간, 메뉴 정보를 보여주는 페이지를 추가했습니다.

## 🔍 변경사항

### 🎨 UI 컴포넌트
- `PlaceBasicInfo`: 장소의 기본 정보(이름, 주소, 전화번호, 키워드, 설명)를 보여주는 컴포넌트
- `PlaceOpeningHours`: 영업 시간 정보를 보여주는 컴포넌트
- `PlaceMenu`: 메뉴와 가격 정보를 보여주는 컴포넌트

### 📦 타입 정의
- `PlaceDetail`: 장소 상세 정보를 위한 타입 정의
- `Menu`: 메뉴 정보를 위한 타입 정의
- `OpenHours`: 영업 시간 정보를 위한 타입 정의

### 💅 스타일
- 스크롤바 스타일을 글로벌로 설정하여 일관된 UI 제공
- 모바일 환경에 최적화된 레이아웃 구현

## 🔗 관련 이슈

Closes #18 

## 🧪 테스트

- [ ] 장소 상세 페이지 접속 시 기본 정보 정상 표시
- [ ] 영업 시간 정보 정상 표시
- [ ] 메뉴 정보 정상 표시
- [ ] 스크롤 동작 확인
- [ ] 모바일 환경에서 레이아웃 확인

## 🚨 주의사항

- 현재는 mock 데이터를 사용하고 있으며, 추후 API 연동 예정
- 위치 정보 권한이 필요할 수 있음 (새로고침해야 잘나오는 현상이 있음)
- 이미지 최적화가 필요할 수 있음