### PR TITLE
Feat/#40 장소 API 연동

### DIFF
--- a/src/app/(main)/(places)/page.tsx
+++ b/src/app/(main)/(places)/page.tsx
@@ -3,7 +3,7 @@ import { Map, SearchBar, CategoryList } from '@/features/place';
 export default function Home() {
   return (
     <div className="relative h-full w-full">
-      <Map />
+      <Map places={[]} />
       <div className="absolute top-0 left-0 z-10 flex w-full flex-col gap-5 px-4 pt-4">
         <SearchBar />
         <CategoryList />

--- a/src/app/(main)/(places)/search/layout.tsx
+++ b/src/app/(main)/(places)/search/layout.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react';
+
+export default function PlacesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <Suspense fallback={<div>페이지 로딩 중...</div>}>{children}</Suspense>
+    </div>
+  );
+}

--- a/src/features/place/api/searchPlaces.ts
+++ b/src/features/place/api/searchPlaces.ts
@@ -1,19 +1,6 @@
-import { fetchApi } from '@/shared/lib/fetchApi';
+// import { fetchApi } from '@/shared/lib/fetchApi';
 
-interface Location {
-  type: 'Point';
-  coordinates: [number, number]; // 경도, 위도 순서 (GeoJSON 표준)
-}
-
-export interface Place {
-  id: number;
-  name: string;
-  thumbnail: string;
-  distance: string; // API 응답이 문자열일 수 있음
-  moment_count: string; // API 응답이 문자열일 수 있음
-  keywords: string[];
-  location: Location;
-}
+import { Place } from '../types';
 
 export interface SearchPlacesResponse {
   total: number;
@@ -21,20 +8,22 @@ export interface SearchPlacesResponse {
 }
 
 export interface SearchPlacesParams {
-  query: string;
   lat: string;
   lng: string;
-  category?: string;
+  query: string | null;
+  category: string | null;
 }
 
 export async function searchPlaces(
   params: SearchPlacesParams,
 ): Promise<SearchPlacesResponse> {
   try {
+    console.group(params);
+    /*
     const queryParams = new URLSearchParams({
-      query: params.query,
       lat: params.lat,
       lng: params.lng,
+      ...(params.query && { query: params.query }),
       ...(params.category && { category: params.category }),
     });
 
@@ -42,10 +31,78 @@ export async function searchPlaces(
       `/api/v1/places/search?${queryParams.toString()}`,
     );
 
+
     return response;
+    */
+
+    return {
+      total: 5,
+      places: [
+        {
+          id: 1,
+          name: '늘솜당 베이커리',
+          thumbnail: 'https://picsum.photos/seed/bakery1/200/200',
+          distance: '150',
+          moment_count: '5',
+          keywords: ['베이커리', '커피', '디저트'],
+          location: {
+            type: 'Point',
+            coordinates: [127.1075, 37.4008],
+          },
+        },
+        {
+          id: 2,
+          name: '판교 중앙공원',
+          thumbnail: 'https://picsum.photos/seed/park2/200/200',
+          distance: '300',
+          moment_count: '12',
+          keywords: ['공원', '산책', '나들이'],
+          location: {
+            type: 'Point',
+            coordinates: [127.1052, 37.3995],
+          },
+        },
+        {
+          id: 3,
+          name: '스타벅스 판교H스퀘어점',
+          thumbnail: 'https://picsum.photos/seed/starbucks3/200/200',
+          distance: '80',
+          moment_count: '25',
+          keywords: ['카페', '커피', '와이파이'],
+          location: {
+            type: 'Point',
+            coordinates: [127.1061, 37.4015],
+          },
+        },
+        {
+          id: 4,
+          name: 'CGV 판교',
+          thumbnail: 'https://picsum.photos/seed/movie4/200/200',
+          distance: '500',
+          moment_count: '8',
+          keywords: ['영화관', '팝콘', '데이트'],
+          location: {
+            type: 'Point',
+            coordinates: [127.1088, 37.3982],
+          },
+        },
+        {
+          id: 5,
+          name: '서현역 맛집거리',
+          thumbnail: 'https://picsum.photos/seed/food5/200/200',
+          distance: '250',
+          moment_count: '30',
+          keywords: ['음식점', '한식', '양식', '모임'],
+          location: {
+            type: 'Point',
+            coordinates: [127.1045, 37.4021],
+          },
+        },
+      ],
+    };
   } catch (error) {
     console.error('장소 검색 실패:', error);
-    // 프로덕션에서는 사용자에게 친화적인 에러 처리 또는 로깅 서비스 연동 고려
+    // TODO: 프로덕션에서는 사용자에게 친화적인 에러 처리 또는 로깅 서비스 연동 고려
     throw error; // 에러를 다시 throw하여 호출부에서 처리할 수 있도록 함
   }
 }

--- a/src/features/place/components/category-list/Category.tsx
+++ b/src/features/place/components/category-list/Category.tsx
@@ -2,11 +2,15 @@
 
 import { useRouter } from 'next/navigation';
 
+import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '../../constants';
+
 export function Category({ category }: { category: string }) {
   const router = useRouter();
 
   const handleClick = (category: string) => {
-    router.push(`/search?category=${category}`);
+    router.push(
+      `/search?category=${category}&lat=${DEFAULT_LATITUDE}&lng=${DEFAULT_LONGITUDE}`,
+    );
   };
 
   return (

--- a/src/features/place/components/map/Map.tsx
+++ b/src/features/place/components/map/Map.tsx
@@ -1,36 +1,79 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import {
-  DEFAULT_LATITUDE,
-  DEFAULT_LONGITUDE,
-  initializeMap,
-} from '../../utils';
+import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '../../constants';
+import { Place } from '../../types';
+import { createPlaceMarkers, initializeMap } from '../../utils';
+import { PlaceBottomSheet } from '../place-bottom-sheet';
 
 import { loadKakaoMapScript } from '@/shared/lib/map';
 
-export function Map() {
+export interface MapProps {
+  places: Place[];
+}
+
+export function Map({ places }: MapProps) {
+  const mapRef = useRef<kakao.maps.Map | null>(null);
+  const [isMapLoaded, setIsMapLoaded] = useState(false);
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  const [selectedPlaceForSheet, setSelectedPlaceForSheet] =
+    useState<Place | null>(null);
+
+  const handleMarkerClickForSheet = (place: Place) => {
+    setSelectedPlaceForSheet(place);
+    setIsBottomSheetOpen(true);
+  };
+
   useEffect(() => {
     loadKakaoMapScript(() => {
       if (window.kakao && window.kakao.maps) {
         window.kakao.maps.load(() => {
           const mapContainer = document.getElementById('map');
           if (mapContainer) {
-            initializeMap(mapContainer, DEFAULT_LATITUDE, DEFAULT_LONGITUDE);
+            const initializedMap = initializeMap(
+              mapContainer,
+              DEFAULT_LATITUDE,
+              DEFAULT_LONGITUDE,
+            );
+            mapRef.current = initializedMap;
+            setIsMapLoaded(true);
           } else {
-            console.error('Map container element not found.');
+            console.error(
+              '[Map Initial useEffect] Map container element not found.',
+            );
           }
         });
+      } else {
+        console.error(
+          '[Map Initial useEffect] Kakao maps object not found after script load.',
+        );
       }
     });
   }, []);
 
+  useEffect(() => {
+    if (isMapLoaded && mapRef.current) {
+      if (places && places.length > 0) {
+        createPlaceMarkers(mapRef.current, places, handleMarkerClickForSheet);
+      } else {
+        createPlaceMarkers(mapRef.current, [], handleMarkerClickForSheet);
+      }
+    }
+  }, [places, isMapLoaded]);
+
   return (
-    <div
-      id="map"
-      className="absolute inset-0 z-0 h-full w-full"
-      style={{ minHeight: '100vh' }}
-    />
+    <>
+      <div
+        id="map"
+        className="absolute inset-0 z-0 h-full w-full"
+        style={{ minHeight: '100vh' }}
+      />
+      <PlaceBottomSheet
+        isOpen={isBottomSheetOpen}
+        onOpenChange={setIsBottomSheetOpen}
+        place={selectedPlaceForSheet}
+      />
+    </>
   );
 }

--- a/src/features/place/components/place-bottom-sheet/PlaceBottomSheet.tsx
+++ b/src/features/place/components/place-bottom-sheet/PlaceBottomSheet.tsx
@@ -2,31 +2,44 @@
 
 import { Drawer } from 'vaul';
 
+import { Place } from '../../types';
 import { PlaceItem } from '../place-item';
 
 interface PlaceBottomSheetProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
+  place: Place | null;
 }
 
 export function PlaceBottomSheet({
   isOpen,
   onOpenChange,
+  place,
 }: PlaceBottomSheetProps) {
+  if (!place) {
+    return null;
+  }
+
   return (
     <Drawer.Root open={isOpen} onOpenChange={onOpenChange}>
       <Drawer.Portal>
-        <Drawer.Overlay className="fixed inset-0 z-10 bg-black/40" />
-        <Drawer.Content className="fixed right-0 bottom-0 left-0 z-100 mx-auto flex h-fit w-full max-w-[430px] flex-col rounded-t-[10px] bg-gray-100 outline-none">
+        <Drawer.Overlay className="fixed inset-0 z-40 bg-black/40" />
+        <Drawer.Content className="fixed right-0 bottom-0 left-0 z-50 mx-auto flex h-fit w-full max-w-[430px] flex-col rounded-t-[10px] bg-gray-100 outline-none">
           <div className="flex-1 rounded-t-[10px] bg-white p-4">
-            <div className="mx-auto mb-3 h-1.5 w-12 flex-shrink-0 rounded-full" />
+            <div className="mx-auto mb-3 h-1.5 w-12 flex-shrink-0 rounded-full bg-gray-300" />
             <div className="mx-auto max-w-md">
               <div className="relative">
-                <Drawer.Title className="hidden">경복궁</Drawer.Title>
-                <Drawer.Description className="hidden">
-                  장소 정보를 확인할 수 있는 드로어입니다.
+                <Drawer.Title className="sr-only">{place.name}</Drawer.Title>
+                <Drawer.Description className="sr-only">
+                  {place.name} 장소 정보를 확인할 수 있는 드로어입니다.
                 </Drawer.Description>
-                <PlaceItem isDetailButton />
+                <PlaceItem
+                  id={place.id}
+                  name={place.name}
+                  thumbnail={place.thumbnail}
+                  keywords={place.keywords}
+                  isDetailButton
+                />
               </div>
             </div>
           </div>

--- a/src/features/place/components/place-item/PlaceItem.tsx
+++ b/src/features/place/components/place-item/PlaceItem.tsx
@@ -5,19 +5,19 @@ import { useRouter } from 'next/navigation';
 import { KeywordList } from '../keyword-list';
 
 export interface PlaceItemProps {
-  id?: number;
-  name?: string;
-  thumbnail?: string;
-  keywords?: string[];
+  id: number;
+  name: string;
+  thumbnail: string;
+  keywords: string[];
   isClickable?: boolean;
   isDetailButton?: boolean;
 }
 
 export function PlaceItem({
-  id = 1,
-  name = '경복궁',
-  thumbnail = 'https://images.unsplash.com/photo-1575936123452-b67c3203c357',
-  keywords = ['유물', '조용한', '한적한'],
+  id,
+  name,
+  thumbnail,
+  keywords,
   isClickable,
   isDetailButton,
 }: PlaceItemProps) {

--- a/src/features/place/components/place-list/PlaceList.tsx
+++ b/src/features/place/components/place-list/PlaceList.tsx
@@ -3,9 +3,14 @@
 import { useEffect, useRef, useState } from 'react';
 import { Drawer } from 'vaul';
 
+import { Place } from '../../types';
 import { PlaceItem } from '../place-item';
 
-export function PlaceList() {
+export interface PlaceListProps {
+  places: Place[];
+}
+
+export function PlaceList({ places }: PlaceListProps) {
   const snapPoints = ['200px', '355px', 1];
   const minSnap = snapPoints[0];
 
@@ -42,14 +47,14 @@ export function PlaceList() {
           </Drawer.Description>
           <div className="my-10 flex-1 overflow-y-auto px-4 pb-10">
             <div className="space-y-8">
-              {Array.from({ length: 20 }).map((_, i) => (
-                <div key={i} className="border-b border-zinc-200 pb-8">
+              {places.map((place) => (
+                <div key={place.id} className="border-b border-zinc-200 pb-8">
                   <PlaceItem
-                    key={i}
-                    id={i}
-                    name={`장소 ${i + 1}`}
-                    thumbnail={`https://placehold.co/100x100`}
-                    keywords={['키워드1', '키워드2', '키워드3']}
+                    key={place.id}
+                    id={place.id}
+                    name={place.name}
+                    thumbnail={place.thumbnail}
+                    keywords={place.keywords}
                     isClickable
                   />
                 </div>

--- a/src/features/place/components/search-bar/SearchBar.tsx
+++ b/src/features/place/components/search-bar/SearchBar.tsx
@@ -3,6 +3,7 @@
 import { Search } from 'iconoir-react';
 import { useRouter } from 'next/navigation';
 
+import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '../../constants';
 import { useSearchBar } from '../../hooks/useSearchBar';
 
 export interface SearchBarProps {
@@ -26,7 +27,9 @@ export function SearchBar({
     const validatedQuery = validateSearch(searchQuery);
 
     if (validatedQuery) {
-      router.push(`/search?q=${encodeURIComponent(validatedQuery)}`);
+      router.push(
+        `/search?q=${encodeURIComponent(validatedQuery)}&lat=${DEFAULT_LATITUDE}&lng=${DEFAULT_LONGITUDE}`,
+      );
     }
   };
 

--- a/src/features/place/constants/index.ts
+++ b/src/features/place/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './map';

--- a/src/features/place/constants/map.ts
+++ b/src/features/place/constants/map.ts
@@ -1,0 +1,6 @@
+export const RADIUS_OFFSET = 0.005; // 약 1km
+export const MIN_LEVEL = 1;
+export const MAX_LEVEL = 3;
+
+export const DEFAULT_LATITUDE = 37.400271334747096;
+export const DEFAULT_LONGITUDE = 127.10698765491078;

--- a/src/features/place/types/place.ts
+++ b/src/features/place/types/place.ts
@@ -2,6 +2,21 @@ export interface CategoriesResponse {
   categories: string[];
 }
 
+interface Location {
+  type: 'Point';
+  coordinates: [number, number]; // 경도, 위도 순서 (GeoJSON 표준)
+}
+
+export interface Place {
+  id: number;
+  name: string;
+  thumbnail: string;
+  distance: string; // API 응답이 문자열일 수 있음
+  moment_count: string; // API 응답이 문자열일 수 있음
+  keywords: string[];
+  location: Location;
+}
+
 export interface PlaceDetail {
   id: number;
   name: string;


### PR DESCRIPTION
## 📝 PR 개요

이 PR은 장소 바텀 시트에 장소 데이터를 받아서 그려지도록 기능을 추가하고, map 컴포넌트가 장소 데이터를 받아서 핀을 그리도록 수정합니다.

## 🔍 변경사항

- 장소 바텀 시트에 장소 데이터 받아서 그리도록 추가
- map 컴포넌트가 장소 데이터를 받아서 핀을 그리도록 수정
- 장소 리스트 컴포넌트가 장소 props를 받도록 추가
- map 관련 상수를 내보내기
- place 타입 정의
- 검색 페이지로 이동할 때 위도, 경도 값을 포함하도록 추가
- API 임시 더미 데이터 사용으로 변경
- 맵 페이지 구성
- 맵 관련 상수를 별도의 폴더에서 관리하도록 변경

## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->

## 📸 스크린샷 (Optional)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a611866a-57a5-4d69-aacd-63b1a6ac4fde" />

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/889ab75d-aca7-4164-91b1-776435386c90" />


## 🧪 테스트 (Optional)

<!-- 테스트 방법 및 결과 -->

- [ ] 장소 데이터가 올바르게 표시되는지 확인
- [ ] 핀이 올바른 위치에 그려지는지 확인

