### PR TITLE
Feat/#44 프로필 이미지 업로드 API 연동

### DIFF
--- a/src/shared/api/getPresignedUrl.ts
+++ b/src/shared/api/getPresignedUrl.ts
@@ -1,0 +1,38 @@
+import { fetchApi } from '../lib/fetchApi';
+
+interface PresignedUrlRequestBody {
+  fileName: string;
+  contentType: string;
+  uploadType: 'profile';
+}
+
+export interface PresignedUrlResponseData {
+  signedUrl: string;
+  objectUrl: string;
+  expiresIn: number;
+}
+
+/**
+ * 이미지 업로드용 Presigned URL을 발급받는 함수
+ * @param fileName 업로드할 파일명 (예: "image.jpg")
+ * @param contentType 파일의 MIME 타입 (예: "image/jpeg")
+ * @param uploadType 업로드 타입 (현재는 "profile"만 지원 가정)
+ * @returns Promise<PresignedUrlResponseData> - Presigned URL 정보
+ * @throws FetchApiError - API 요청 실패 시
+ */
+export async function getPresignedUrl(
+  fileName: string,
+  contentType: string,
+  uploadType: 'profile',
+): Promise<PresignedUrlResponseData> {
+  const requestBody: PresignedUrlRequestBody = {
+    fileName,
+    contentType,
+    uploadType,
+  };
+
+  return fetchApi<PresignedUrlResponseData>('/api/v1/gcs/presigned-urls', {
+    method: 'POST',
+    body: JSON.stringify(requestBody),
+  });
+}

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,1 @@
+export * from './getPresignedUrl';

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useImageUpload';

--- a/src/shared/hooks/useImageUpload.ts
+++ b/src/shared/hooks/useImageUpload.ts
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+
+import { getPresignedUrl, type PresignedUrlResponseData } from '@/shared/api';
+import { FetchApiError } from '@/shared/lib/fetchApi';
+
+export type UploadType = 'profile';
+
+interface UseImageUploadResult {
+  uploadImage: (file: File, uploadType: UploadType) => Promise<string | null>;
+  isLoading: boolean;
+  error: Error | null;
+  uploadedObjectUrl: string | null;
+}
+
+export function useImageUpload(): UseImageUploadResult {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [uploadedObjectUrl, setUploadedObjectUrl] = useState<string | null>(
+    null,
+  );
+
+  const uploadImage = async (
+    file: File,
+    uploadType: UploadType,
+  ): Promise<string | null> => {
+    setIsLoading(true);
+    setError(null);
+    setUploadedObjectUrl(null);
+
+    try {
+      const presignedData: PresignedUrlResponseData = await getPresignedUrl(
+        file.name,
+        file.type,
+        uploadType,
+      );
+
+      const uploadResponse = await fetch(presignedData.signedUrl, {
+        method: 'PUT',
+        body: file,
+        headers: {
+          'Content-Type': file.type,
+        },
+      });
+
+      if (!uploadResponse.ok) {
+        throw new Error(
+          `GCS 업로드 실패: ${uploadResponse.status} ${uploadResponse.statusText}`,
+        );
+      }
+
+      setUploadedObjectUrl(presignedData.objectUrl);
+      setIsLoading(false);
+      return presignedData.objectUrl;
+    } catch (err) {
+      console.error('이미지 업로드 중 에러 발생:', err);
+      if (err instanceof FetchApiError || err instanceof Error) {
+        setError(err);
+      } else {
+        setError(new Error('알 수 없는 에러가 발생했습니다.'));
+      }
+      setIsLoading(false);
+      return null;
+    }
+  };
+
+  return {
+    uploadImage,
+    isLoading,
+    error,
+    uploadedObjectUrl,
+  };
+}


### PR DESCRIPTION
## 📝 PR 개요

이번 PR은 이미지 업로드 기능을 개선하고 프로필 폼에 적용하는 것을 주요 내용으로 합니다. 이미지 업로드를 위한 커스텀 훅과 API 함수를 정의하였으며, 이를 프로필 폼에서 사용하여 사용자가 프로필 이미지를 업로드할 수 있도록 기능을 구현했습니다.

## 🔍 변경사항

- 이미지 업로드 관련 로직을 캡슐화하고 재사용성을 높이기 위해 커스텀 React Hook (`useImageUpload`)을 정의했습니다.
- 이미지 Presigned URL을 요청하고 GCS에 업로드하는 과정을 처리합니다.
- 이미지 업로드를 위한 백엔드 API 통신 함수 (`getPresignedUrl`)를 정의했습니다.
- `ProfileForm` 컴포넌트에서 `useImageUpload` 훅과 API 함수를 사용하여 이미지 업로드 기능을 구현했습니다.
  - 사용자가 이미지를 선택하면 미리보기를 제공합니다.
  - 폼 제출 시 선택된 이미지를 GCS에 업로드하고, 반환된 이미지 URL을 프로필 정보와 함께 저장합니다.
  - 업로드 중 로딩 상태 및 오류 발생 시 적절한 UI 피드백을 제공합니다.

## 🔗 관련 이슈
Closes #44 


## 🧪 테스트 (Optional)

<!-- 이 변경사항을 테스트하는 방법을 설명해주세요. -->

- [ ] 프로필 폼에서 이미지 선택 시 미리보기가 정상적으로 표시되는지 확인
- [ ] 유효하지 않은 이미지 파일(크기 초과, 지원하지 않는 형식) 선택 시 에러 메시지가 표시되는지 확인
- [ ] 프로필 폼 제출 시 이미지가 GCS에 정상적으로 업로드되고, 저장된 프로필 정보에 이미지 URL이 올바르게 반영되는지 확인
- [ ] 이미지 업로드 중 로딩 상태가 버튼 및 UI에 적절히 표시되는지 확인
- [ ] 이미지 업로드 실패 시 에러 메시지가 사용자에게 안내되는지 확인

