### PR TITLE
Feat/#46 장소 상세 페이지 API 연동

### DIFF
--- a/src/app/(main)/(places)/places/[id]/page.tsx
+++ b/src/app/(main)/(places)/places/[id]/page.tsx
@@ -1,28 +1,40 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
-
 import {
-  mockPlaceDetail,
+  getPlaceDetail,
   PlaceBasicInfo,
   PlaceMenu,
   PlaceOpenHours,
 } from '@/features/place';
 import { Header } from '@/shared/components';
 
-export default function PlaceDetailPage() {
-  const router = useRouter();
-  // TODO: API 연동 시 실제 데이터로 교체
-  const place = mockPlaceDetail;
+interface PlaceDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function PlaceDetailPage({
+  params,
+}: PlaceDetailPageProps) {
+  const { id } = await params;
+
+  const place = await getPlaceDetail(id);
+
+  if (!place) {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center">
+        <div className="text-2xl font-bold">존재하지 않는 장소입니다.</div>
+      </div>
+    );
+  }
+
+  const { opening_hours, menu, ...placeBasicInfo } = place;
 
   return (
     <div className="flex h-screen flex-col">
-      <Header showBackButton onBackClick={() => router.back()} />
+      <Header showBackButton />
       <div className="flex-1 overflow-y-auto pb-16">
         <div className="container mx-auto mb-4 px-4 py-5">
-          <PlaceBasicInfo placeBasicInfo={place} />
-          <PlaceOpenHours openHours={place.opening_hours} />
-          <PlaceMenu menu={place.menu} />
+          <PlaceBasicInfo placeBasicInfo={placeBasicInfo} />
+          <PlaceOpenHours openHours={opening_hours} />
+          <PlaceMenu menu={menu} />
         </div>
       </div>
     </div>

--- a/src/features/place/api/getPlaceDetail.ts
+++ b/src/features/place/api/getPlaceDetail.ts
@@ -1,38 +1,6 @@
+import { PlaceDetail } from '../types';
+
 import { fetchApi } from '@/shared/lib/fetchApi';
-
-interface Location {
-  type: 'Point';
-  coordinates: [number, number];
-}
-
-interface OpeningHoursSchedule {
-  day: 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
-  hours?: string;
-  note?: string;
-}
-
-interface OpeningHours {
-  status: string;
-  schedules: OpeningHoursSchedule[];
-}
-
-interface MenuItem {
-  name: string;
-  price: number;
-}
-
-interface PlaceDetail {
-  id: string;
-  name: string;
-  thumbnail: string;
-  address: string;
-  location: Location;
-  keywords: string[];
-  description: string;
-  opening_hours: OpeningHours;
-  phone: string;
-  menu: MenuItem[];
-}
 
 export async function getPlaceDetail(placeId: string): Promise<PlaceDetail> {
   try {

--- a/src/features/place/components/place-open-hours/PlaceOpenHours.tsx
+++ b/src/features/place/components/place-open-hours/PlaceOpenHours.tsx
@@ -26,7 +26,7 @@ export function PlaceOpenHours({ openHours }: PlaceOpenHoursProps) {
             {schedule.hours ? (
               <span className="body-text text-gray-800">{schedule.hours}</span>
             ) : (
-              <span className="body-text text-red-500">{schedule.note}</span>
+              <span className="body-text text-red-500">휴무</span>
             )}
           </div>
         ))}

--- a/src/features/place/types/place.ts
+++ b/src/features/place/types/place.ts
@@ -36,9 +36,8 @@ export interface PlaceDetail {
 export interface OpenHours {
   status: string;
   schedules: {
-    day: string;
+    day: 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
     hours: string | null;
-    note: string | null;
   }[];
 }
 export interface Menu {
@@ -88,37 +87,30 @@ export const mockPlaceDetail: PlaceDetail = {
       {
         day: 'mon',
         hours: '08:00~17:00',
-        note: null,
       },
       {
         day: 'tue',
         hours: '08:00~17:00',
-        note: null,
       },
       {
         day: 'wed',
         hours: '08:00~17:00',
-        note: null,
       },
       {
         day: 'thu',
         hours: '08:00~17:00',
-        note: null,
       },
       {
         day: 'fri',
         hours: '08:00~17:00',
-        note: null,
       },
       {
         day: 'sat',
         hours: null,
-        note: '정기휴무 (매주 토요일)',
       },
       {
         day: 'sun',
         hours: null,
-        note: '정기휴무 (매주 일요일)',
       },
     ],
   },

--- a/src/shared/components/header/Header.tsx
+++ b/src/shared/components/header/Header.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import { NavArrowLeft } from 'iconoir-react';
+import { useRouter } from 'next/navigation';
 
 export interface HeaderProps {
   title?: string;
@@ -13,11 +16,20 @@ export function Header({
   onBackClick,
   rightElement,
 }: HeaderProps) {
+  const router = useRouter();
+
+  const handleBackClick = () => {
+    if (onBackClick) {
+      onBackClick();
+    } else {
+      router.back();
+    }
+  };
   return (
     <header className="flex h-16 items-center justify-between border-b border-b-gray-200 px-4">
       <div className="flex items-center">
         {showBackButton && (
-          <button onClick={onBackClick} className="flex items-center gap-2">
+          <button onClick={handleBackClick} className="flex items-center gap-2">
             <NavArrowLeft className="h-6 w-6" />
           </button>
         )}


### PR DESCRIPTION
## 📝 PR 개요

이번 PR은 장소 상세보기 페이지의 기능 개선 및 코드 정리를 주요 내용으로 합니다. 상세보기 페이지에 API를 연동하여 실제 데이터를 표시하도록 구현했으며, 영업시간 정보가 없는 경우 '휴무'로 표시되도록 UI를 개선했습니다. 또한, 중복된 타입 정의를 정리하고 헤더 컴포넌트의 뒤로 가기 동작을 유연하게 변경했습니다.

## 🔍 변경사항

- **장소 상세보기 페이지 API 연동**:
  - 장소 상세 정보를 불러오는 API를 호출하여 페이지에 실제 데이터를 연동했습니다.
  - 이를 통해 사용자는 특정 장소에 대한 상세한 정보를 확인할 수 있습니다.
- **영업시간 표시 개선**:
  - 장소의 영업시간(`hours`) 정보가 없는 (`null`) 경우, '휴무'로 표시되도록 UI 로직을 변경했습니다. (기존 `note` 관련 로직 제거)
- **중복 타입 정리**:
  - 프로젝트 내에 중복으로 정의되어 있던 타입들을 식별하고 정리하여 코드의 일관성과 유지보수성을 향상했습니다.
- **헤더 뒤로 가기 기능 유연화**:
  - 헤더 컴포넌트에서 `onBackClick` 함수가 별도로 정의되지 않은 경우, 기본적으로 `router.back()`을 호출하여 이전 페이지로 이동하도록 설정했습니다.

## 🔗 관련 이슈

Closes #46 

## 🧪 테스트 (Optional)

<!-- 이 변경사항을 테스트하는 방법을 설명해주세요. -->

- [ ] 장소 상세보기 페이지 접속 시 API를 통해 장소 정보가 올바르게 표시되는지 확인
- [ ] 영업시간 정보가 없는 장소의 경우 '휴무'로 정상적으로 표시되는지 확인
- [ ] 헤더의 뒤로 가기 버튼이 의도대로 동작하는지 (커스텀 `onBackClick` 또는 `router.back()`) 확인
- [ ] 타입 정리 후 빌드 및 런타임 에러가 없는지 확인

## 🚨 주의사항 (Optional)

- 장소 상세 API의 응답 형식 및 데이터 유효성에 대한 최종 확인이 필요합니다.
- 다양한 장소 데이터(영업시간 유/무, 모든 필드 데이터 유/무 등)에 대해 상세보기 페이지가 올바르게 렌더링되는지 충분한 테스트가 필요합니다.
