### PR TITLE
Feat/#48 장소 상세페이지 보완 (휴게시간, 메뉴 UI)

### DIFF
--- a/src/app/(main)/(places)/places/[id]/page.tsx
+++ b/src/app/(main)/(places)/places/[id]/page.tsx
@@ -27,14 +27,17 @@ export default async function PlaceDetailPage({
 
   const { opening_hours, menu, ...placeBasicInfo } = place;
 
+  const isMenuEmpty = menu.length === 0;
+  const isOpenHoursEmpty = opening_hours.status === '영업 여부 확인 필요';
+
   return (
     <div className="flex h-screen flex-col">
       <Header showBackButton />
       <div className="flex-1 overflow-y-auto pb-16">
         <div className="container mx-auto mb-4 px-4 py-5">
           <PlaceBasicInfo placeBasicInfo={placeBasicInfo} />
-          <PlaceOpenHours openHours={opening_hours} />
-          <PlaceMenu menu={menu} />
+          {!isOpenHoursEmpty && <PlaceOpenHours openHours={opening_hours} />}
+          {!isMenuEmpty && <PlaceMenu menu={menu} />}
         </div>
       </div>
     </div>

--- a/src/app/(main)/(places)/places/[id]/page.tsx
+++ b/src/app/(main)/(places)/places/[id]/page.tsx
@@ -34,7 +34,7 @@ export default async function PlaceDetailPage({
     <div className="flex h-screen flex-col">
       <Header showBackButton />
       <div className="flex-1 overflow-y-auto pb-16">
-        <div className="container mx-auto mb-4 px-4 py-5">
+        <div className="container mx-auto mb-4 px-4 pt-5 pb-10">
           <PlaceBasicInfo placeBasicInfo={placeBasicInfo} />
           {!isOpenHoursEmpty && <PlaceOpenHours openHours={opening_hours} />}
           {!isMenuEmpty && <PlaceMenu menu={menu} />}

--- a/src/features/place/components/place-menu/PlaceMenu.tsx
+++ b/src/features/place/components/place-menu/PlaceMenu.tsx
@@ -1,15 +1,29 @@
+'use client';
+
+import { useState } from 'react';
+
 import { Menu } from '../../types';
+
+import { ToggleMenuButton } from './ToggleMenuButton';
 
 interface PlaceMenuProps {
   menu: Menu[];
 }
 
 export function PlaceMenu({ menu }: PlaceMenuProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleToggle = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  const visibleMenu = isExpanded ? menu : menu.slice(0, 5);
+
   return (
     <div>
       <h2 className="heading-2 mb-3">메뉴</h2>
       <div className="space-y-3">
-        {menu.map((item) => (
+        {visibleMenu.map((item) => (
           <div key={item.name} className="flex items-center justify-between">
             <span className="body-text text-gray-800">{item.name}</span>
             <span className="body-text text-gray-600">
@@ -18,6 +32,9 @@ export function PlaceMenu({ menu }: PlaceMenuProps) {
           </div>
         ))}
       </div>
+      {menu.length > 5 && (
+        <ToggleMenuButton isExpanded={isExpanded} onToggle={handleToggle} />
+      )}
     </div>
   );
 }

--- a/src/features/place/components/place-menu/ToggleMenuButton.tsx
+++ b/src/features/place/components/place-menu/ToggleMenuButton.tsx
@@ -1,0 +1,28 @@
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+
+export interface ToggleMenuButtonProps {
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+export function ToggleMenuButton({
+  isExpanded,
+  onToggle,
+}: ToggleMenuButtonProps) {
+  return (
+    <div className="relative flex w-full justify-center">
+      <div className="absolute bottom-5 left-0 h-full w-full border-b border-gray-200" />
+      <button
+        onClick={onToggle}
+        className="relative mt-5 flex items-center justify-center gap-2 rounded-full bg-gray-100 px-4 py-2 text-gray-500"
+      >
+        {isExpanded ? '메뉴 접기' : '메뉴 더보기'}
+        {isExpanded ? (
+          <ChevronUpIcon className="h-4 w-4" />
+        ) : (
+          <ChevronDownIcon className="h-4 w-4" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/features/place/components/place-open-hours/PlaceOpenHours.tsx
+++ b/src/features/place/components/place-open-hours/PlaceOpenHours.tsx
@@ -7,30 +7,41 @@ export interface PlaceOpenHoursProps {
 export function PlaceOpenHours({ openHours }: PlaceOpenHoursProps) {
   return (
     <div className="mb-6">
-      <h2 className="heading-2 mb-3">영업 시간</h2>
-      <p className="body-text mb-2 font-medium text-green-600">
-        {openHours.status}
-      </p>
-      <div className="space-y-2">
-        {openHours.schedules.map((schedule) => (
-          <div key={schedule.day} className="flex justify-between">
-            <span className="body-text text-gray-600">
-              {schedule.day === 'mon' && '월요일'}
-              {schedule.day === 'tue' && '화요일'}
-              {schedule.day === 'wed' && '수요일'}
-              {schedule.day === 'thu' && '목요일'}
-              {schedule.day === 'fri' && '금요일'}
-              {schedule.day === 'sat' && '토요일'}
-              {schedule.day === 'sun' && '일요일'}
-            </span>
-            {schedule.hours ? (
+      <h2 className="heading-2">영업 시간</h2>
+      {openHours.status === '영업 중' && (
+        <p className="heading-3 my-3 font-medium text-green-600">영업 중</p>
+      )}
+      {openHours.status !== '영업 중' && (
+        <p className="heading-3 my-3 font-medium text-red-600">
+          {openHours.status}
+        </p>
+      )}
+
+      {openHours.schedules.map((schedule) => (
+        <div key={schedule.day} className="my-1 flex justify-between">
+          <span className="body-text text-gray-600">
+            {schedule.day === 'mon' && '월요일'}
+            {schedule.day === 'tue' && '화요일'}
+            {schedule.day === 'wed' && '수요일'}
+            {schedule.day === 'thu' && '목요일'}
+            {schedule.day === 'fri' && '금요일'}
+            {schedule.day === 'sat' && '토요일'}
+            {schedule.day === 'sun' && '일요일'}
+          </span>
+          {schedule.hours ? (
+            <div>
               <span className="body-text text-gray-800">{schedule.hours}</span>
-            ) : (
-              <span className="body-text text-red-500">휴무</span>
-            )}
-          </div>
-        ))}
-      </div>
+              {schedule.break_time && (
+                <div className="body-text text-gray-400">
+                  {schedule.break_time} 브레이크 타임
+                </div>
+              )}
+            </div>
+          ) : (
+            <span className="body-text text-red-500">휴무</span>
+          )}
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/features/place/types/place.ts
+++ b/src/features/place/types/place.ts
@@ -11,8 +11,8 @@ export interface Place {
   id: number;
   name: string;
   thumbnail: string;
-  distance: string; // API 응답이 문자열일 수 있음
-  moment_count: string; // API 응답이 문자열일 수 있음
+  distance: string;
+  moment_count: string;
   keywords: string[];
   location: Location;
 }
@@ -34,84 +34,20 @@ export interface PlaceDetail {
 }
 
 export interface OpenHours {
-  status: string;
+  status:
+    | '영업 중'
+    | '영업 종료'
+    | '브레이크 타임'
+    | '휴무일'
+    | '영업 정보 없음'
+    | '영업 여부 확인 필요';
   schedules: {
     day: 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
     hours: string | null;
+    break_time: string | null;
   }[];
 }
 export interface Menu {
   name: string;
   price: number;
 }
-
-export const mockPlaceDetail: PlaceDetail = {
-  id: 1,
-  name: '해목 논현점',
-  address: '서울 강남구 선릉로 145길 14',
-  thumbnail:
-    'https://images.unsplash.com/photo-1563245372-f21724e3856d?q=80&w=1000&auto=format&fit=crop',
-  location: {
-    coordinates: [126.9804, 37.5231],
-    type: 'Point',
-  },
-  keywords: ['포장', '주차', '밀실'],
-  description:
-    '다양한 맛과 특별한 장어의 만남. 다양한 맛과 특별한 장어의 만남. 다양한 맛과 특별한 장어의 만남. 다양한 맛과 특별한 장어의 만남.',
-  phone: '0507-0505-0607',
-  menu: [
-    {
-      name: '장어구이',
-      price: 25000,
-    },
-    {
-      name: '소주',
-      price: 5000,
-    },
-    {
-      name: '맥주',
-      price: 5000,
-    },
-    {
-      name: '장어찜',
-      price: 35000,
-    },
-    {
-      name: '미꾸라지탕',
-      price: 15000,
-    },
-  ],
-  opening_hours: {
-    status: '영업 중',
-    schedules: [
-      {
-        day: 'mon',
-        hours: '08:00~17:00',
-      },
-      {
-        day: 'tue',
-        hours: '08:00~17:00',
-      },
-      {
-        day: 'wed',
-        hours: '08:00~17:00',
-      },
-      {
-        day: 'thu',
-        hours: '08:00~17:00',
-      },
-      {
-        day: 'fri',
-        hours: '08:00~17:00',
-      },
-      {
-        day: 'sat',
-        hours: null,
-      },
-      {
-        day: 'sun',
-        hours: null,
-      },
-    ],
-  },
-};

--- a/src/features/user/components/profile/Profile.tsx
+++ b/src/features/user/components/profile/Profile.tsx
@@ -17,7 +17,11 @@ export function Profile({
     <div className="flex flex-col items-center px-4 py-6">
       <div className="relative mb-4 aspect-square w-32 overflow-hidden rounded-full">
         {profile_image ? (
-          <img src={profile_image} alt={username} className="object-cover" />
+          <img
+            src={profile_image}
+            alt={username}
+            className="h-full w-full object-cover"
+          />
         ) : (
           <div className="flex h-full w-full items-center justify-center bg-gray-200">
             <User className="h-12 w-12 text-gray-400" />


### PR DESCRIPTION
## 📝 PR 개요

이 PR은 장소 상세페이지의 UI를 보완하여 사용자 경험을 개선합니다. 메뉴가 5개 이상일 경우 '메뉴 더보기' 버튼을 추가하여 나머지 메뉴를 펼쳐볼 수 있도록 하였으며, 영업 시간에 브레이크 타임을 명시하여 정보를 더욱 명확하게 전달합니다.

## 🔍 변경사항

- 메뉴가 5개 이상일 경우 '메뉴 더보기' 버튼을 추가하여 나머지 메뉴를 펼쳐볼 수 있도록 기능 추가
- 영업 시간에 브레이크 타임 정보를 추가하여 사용자에게 명확한 정보를 제공
- 메뉴 및 영업 시간 정보가 없을 경우 해당 섹션이 보이지 않도록 스타일 수정
- 이미지 정렬 문제 수정

## 🔗 관련 이슈

Closes #48 

## 📸 스크린샷 (Optional)

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/32a1e48b-b635-42dc-b408-78faeedd0fd7" />

## 🧪 테스트 (Optional)

- [ ] 메뉴가 5개 이상일 때 '메뉴 더보기' 버튼이 정상적으로 작동하는지 확인
- [ ] 영업 시간에 브레이크 타임이 올바르게 표시되는지 확인

## 🚨 주의사항 (Optional)

- UI 변경사항이 사용자 경험에 미치는 영향을 고려하여 리뷰 부탁드립니다. 
