### PR TITLE
Feat/#57 로딩 화면 및 예외 화면 생성

### DIFF
--- a/src/app/(main)/(places)/search/layout.tsx
+++ b/src/app/(main)/(places)/search/layout.tsx
@@ -6,8 +6,16 @@ export default function PlacesLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div>
-      <Suspense fallback={<div>페이지 로딩 중...</div>}>{children}</Suspense>
+    <div className="flex h-full w-full flex-col">
+      <Suspense
+        fallback={
+          <div className="flex h-full w-full items-center justify-center">
+            <div className="text-center text-gray-500">로딩중...</div>
+          </div>
+        }
+      >
+        {children}
+      </Suspense>
     </div>
   );
 }

--- a/src/app/(main)/(places)/search/page.tsx
+++ b/src/app/(main)/(places)/search/page.tsx
@@ -19,9 +19,11 @@ export default function SearchPage() {
   const category = searchParams.get('category');
 
   const [places, setPlaces] = useState<Place[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     const fetchPlaces = async () => {
+      setIsLoading(true);
       const currentLat = lat || undefined;
       const currentLng = lng || undefined;
       const currentQuery = query || null;
@@ -40,6 +42,8 @@ export default function SearchPage() {
         } catch (error) {
           console.error('장소 검색 API 호출 중 오류:', error);
           setPlaces([]);
+        } finally {
+          setIsLoading(false);
         }
       } else {
         console.log('위치 정보(lat, lng)가 없어 장소를 검색할 수 없습니다.');
@@ -49,15 +53,33 @@ export default function SearchPage() {
     fetchPlaces();
   }, [query, lat, lng, category]);
 
+  if (isLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="text-center text-gray-500">장소를 검색중입니다...</div>
+      </div>
+    );
+  }
+
   return (
     <div className="relative h-full w-full">
-      <Map places={places} />
       <div className="absolute top-0 left-0 z-10 flex w-full flex-col gap-5">
-        <Suspense fallback={<div>Loading SearchBar...</div>}>
+        <Suspense>
           <SearchResultBar />
         </Suspense>
       </div>
-      <PlaceList places={places} />
+      {places.length > 0 ? (
+        <>
+          <Map places={places} />
+          <PlaceList places={places} />
+        </>
+      ) : (
+        <div className="flex h-full w-full items-center justify-center">
+          <div className="text-center text-gray-500">
+            검색된 장소가 없습니다.
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -11,7 +11,11 @@ export default function MyPage() {
   const { user } = useUser();
 
   if (!user) {
-    return <div>로딩중...</div>;
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        로딩중...
+      </div>
+    );
   }
 
   const { username, profile_image, introduction } = user;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,6 +71,7 @@ body {
   max-width: 430px;
   min-width: 375px;
   min-height: 100vh;
+  height: 100vh;
   background: var(--background);
   position: relative;
   overflow-x: hidden;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${pretendard.variable}`}>
         <div className="mobile-container relative">
-          <main className="min-h-screen w-full">
+          <main className="h-full w-full">
             {children}
             <Toaster />
           </main>

--- a/src/features/place/components/place-basic-info/PlaceBasicInfo.tsx
+++ b/src/features/place/components/place-basic-info/PlaceBasicInfo.tsx
@@ -10,11 +10,19 @@ export function PlaceBasicInfo({ placeBasicInfo }: PlaceBasicInfoProps) {
   return (
     <>
       <div className="relative mb-6 aspect-square w-full overflow-hidden rounded-lg">
-        <img
-          src={thumbnail}
-          alt={name}
-          className="h-full w-full object-cover"
-        />
+        {thumbnail ? (
+          <img
+            src={thumbnail}
+            alt={name}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="h-full w-full bg-gray-200">
+            <div className="flex h-full w-full items-center justify-center">
+              <div className="text-center text-gray-500">이미지 없음</div>
+            </div>
+          </div>
+        )}
       </div>
       <h1 className="heading-1 mb-4">{name}</h1>
       <div className="mb-6">

--- a/src/features/place/components/place-item/PlaceItem.tsx
+++ b/src/features/place/components/place-item/PlaceItem.tsx
@@ -33,11 +33,19 @@ export function PlaceItem({
         onClick={isClickable ? handleDetailClick : undefined}
       >
         <div className="h-24 w-24 flex-shrink-0 overflow-hidden rounded-lg">
-          <img
-            src={thumbnail}
-            alt="장소 이미지"
-            className="h-full w-full object-cover"
-          />
+          {thumbnail ? (
+            <img
+              src={thumbnail}
+              alt="장소 이미지"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="h-full w-full bg-gray-200">
+              <div className="flex h-full w-full items-center justify-center">
+                <div className="text-center text-gray-500">이미지 없음</div>
+              </div>
+            </div>
+          )}
         </div>
         <div className="flex flex-col gap-2">
           <div className="heading-3">{name}</div>

--- a/src/features/place/components/place-list/PlaceList.tsx
+++ b/src/features/place/components/place-list/PlaceList.tsx
@@ -11,7 +11,7 @@ export interface PlaceListProps {
 }
 
 export function PlaceList({ places }: PlaceListProps) {
-  const snapPoints = ['200px', '355px', 1];
+  const snapPoints = ['300px', '400px', 1];
   const minSnap = snapPoints[0];
 
   const [isOpen, setIsOpen] = useState(true);

--- a/src/features/place/components/place-list/PlaceList.tsx
+++ b/src/features/place/components/place-list/PlaceList.tsx
@@ -11,7 +11,7 @@ export interface PlaceListProps {
 }
 
 export function PlaceList({ places }: PlaceListProps) {
-  const snapPoints = ['300px', '400px', 1];
+  const snapPoints = ['200px', '355px', 1];
   const minSnap = snapPoints[0];
 
   const [isOpen, setIsOpen] = useState(true);
@@ -37,7 +37,7 @@ export function PlaceList({ places }: PlaceListProps) {
     >
       <Drawer.Portal>
         <Drawer.Content
-          className="fixed right-0 bottom-0 left-0 z-50 mx-auto flex max-w-[430px] flex-col rounded-t-2xl border-t bg-white shadow-lg"
+          className="fixed right-0 bottom-0 left-0 z-50 mx-auto flex h-full max-w-[430px] flex-col rounded-t-2xl border-t bg-white shadow-lg"
           style={{ maxHeight: '100dvh' }}
         >
           <div className="mx-auto mt-4 h-1.5 w-12 rounded-full bg-zinc-300" />


### PR DESCRIPTION
## 📝 PR 개요

이 PR은 장소 검색 기능과 관련된 UI/UX를 개선했습니다.
주요 변경 사항으로는 장소 리스트의 높이 표시 방식을 일관성 있게 조정하고, 검색 중 로딩 화면 및 검색 결과가 없을 때의 화면을 명확하게 구성하여 사용자 경험을 향상시키는 데 중점을 두었습니다.

## 🔍 변경사항

- **장소 리스트(PlaceList) 높이 표시 방식 개선**
  - `PlaceList` Drawer의 초기 높이가 일관되지 않게 표시되던 문제를 수정하여, 콘텐츠 유무 및 상태에 따라 예측 가능한 높이로 표시되도록 조정했습니다.
  - 스타일을 수정하여 장소 리스트의 전체적인 높이 설정을 명확히 했습니다.
- **검색 경험 개선**
  - 장소 검색 시 사용자에게 로딩 중임을 알리는 화면을 추가했습니다.
  - 검색 결과 데이터가 없을 경우, "검색된 장소가 없습니다"라는 메시지를 명확히 표시하도록 `PlaceList` 컴포넌트를 수정했습니다.
  - 로딩 화면의 레이아웃을 일관성 있게 설정했습니다.
- **이미지 처리 보완**
  - 장소 이미지 데이터가 없을 경우, 기본 더미 이미지가 표시되도록 수정하여 UI 깨짐을 방지했습니다.


## 🔗 관련 이슈

Closes #57 

## 📸 스크린샷 (Optional)

<img width="1512" alt="스크린샷 2025-05-13 오후 10 27 00" src="https://github.com/user-attachments/assets/7d8eae7d-ef39-4a4c-86a6-0818c53bbb5e" />


## 🧪 테스트 (Optional)

- [ ] 장소 검색 시 로딩 화면이 정상적으로 표시되는지 확인
- [ ] 검색 결과가 없을 때 "검색된 장소가 없습니다" 메시지가 `PlaceList` 내에 표시되는지 확인
- [ ] `PlaceList` Drawer의 초기 높이가 다양한 상황(검색 결과 유무 등)에서 일관되게 표시되는지 확인
- [ ] 장소 이미지가 없는 경우 더미 이미지가 잘 나타나는지 확인


## 🚨 주의사항 (Optional)

- `PlaceList`의 높이 관련 변경 사항이 다양한 디바이스 및 화면 크기에서 의도대로 동작하는지 충분한 테스트가 필요합니다.

