### PR TITLE
Refactor/#39 백엔드와 변수명 개선

### DIFF
--- a/src/app/(auth)/auth/consent/page.tsx
+++ b/src/app/(auth)/auth/consent/page.tsx
@@ -20,8 +20,8 @@ export default function Consent() {
   const handleAgreement = async () => {
     try {
       await postAgreement({
-        locationAgreed: true,
-        privacyAgreed: true,
+        location_agreed: true,
+        privacy_agreed: true,
       });
 
       router.push('/auth/signup');

--- a/src/app/(auth)/oauth/kakao/callback/KakaoCallbackClient.tsx
+++ b/src/app/(auth)/oauth/kakao/callback/KakaoCallbackClient.tsx
@@ -35,7 +35,7 @@ export default function KakaoCallbackClient() {
           return;
         }
 
-        if (!response.user.profileCompleted) {
+        if (!response.user.profile_completed) {
           router.push('/auth/consent');
         } else {
           router.push('/');

--- a/src/app/(auth)/oauth/kakao/callback/KakaoCallbackClient.tsx
+++ b/src/app/(auth)/oauth/kakao/callback/KakaoCallbackClient.tsx
@@ -27,7 +27,7 @@ export default function KakaoCallbackClient() {
       }
 
       try {
-        const response = await issueAuthTokens({ authorizationCode: code });
+        const response = await issueAuthTokens({ authorization_code: code });
 
         if (!response || !response.user) {
           console.error('issueAuthTokens 응답에 user 객체 없음', response);

--- a/src/features/user/api/issueAuthTokens.ts
+++ b/src/features/user/api/issueAuthTokens.ts
@@ -11,7 +11,6 @@ export async function issueAuthTokens(
       body: JSON.stringify(body),
     });
 
-    console.log('response', response);
     return response;
   } catch (error) {
     if (error instanceof FetchApiError) {

--- a/src/features/user/api/postAgreement.ts
+++ b/src/features/user/api/postAgreement.ts
@@ -1,22 +1,18 @@
 import { fetchApi, FetchApiError } from '@/shared/lib/fetchApi';
 
 interface AgreementRequestBody {
-  locationAgreed: boolean;
-  privacyAgreed: boolean;
+  location_agreed: boolean;
+  privacy_agreed: boolean;
 }
 
 export async function postAgreement(
   body: AgreementRequestBody,
 ): Promise<string> {
   try {
-    console.log('body', body);
-
     const response = await fetchApi<string>('/api/v1/users/agreement', {
       method: 'POST',
       body: JSON.stringify(body),
     });
-
-    console.log('response', response);
 
     return response;
   } catch (error) {

--- a/src/features/user/types/token.ts
+++ b/src/features/user/types/token.ts
@@ -10,17 +10,17 @@ export interface TokensRequestBody {
 
 // /api/v1/auth/tokens 성공 응답 데이터 타입
 export interface AuthTokens {
-  accessToken: string;
-  expiresIn: number;
-  newUser: boolean;
-  refreshToken: string | null;
-  tokenType: 'Bearer';
+  access_token: string;
+  expires_in: number;
+  new_user: boolean;
+  refresh_token: string | null;
+  token_type: 'Bearer';
   user: {
     id: string;
-    locationAgree: boolean;
-    privacyAgreed: boolean;
-    profileCompleted: boolean;
-    profileImageUrl: string | null;
+    location_agreed: boolean;
+    privacy_agreed: boolean;
+    profile_completed: boolean;
+    profile_image_url: string | null;
     provider: 'KAKAO';
     username: string;
   };

--- a/src/features/user/types/token.ts
+++ b/src/features/user/types/token.ts
@@ -5,7 +5,7 @@ export interface OAuthRedirectResponse {
 
 // /api/v1/auth/tokens 요청 바디 타입
 export interface TokensRequestBody {
-  authorizationCode: string;
+  authorization_code: string;
 }
 
 // /api/v1/auth/tokens 성공 응답 데이터 타입


### PR DESCRIPTION
## 📝 PR 개요

이 PR은 백엔드와의 타입 통일 및 상세 페이지에서 일부 정보가 없을 때도 정상적으로 동작하도록 UI/UX를 개선합니다.

## 🔍 변경사항

- 백엔드와 프론트엔드 타입 정의를 통일하여 데이터 일관성을 확보 (`refactor: 백엔드와 타입 통일`)
- 상세 페이지에서 주소, 전화번호 정보가 없어도 정상적으로 렌더링되도록 수정 (`fix: 상세 페이지 주소, 폰 번호 정보 없어도 정상적으로 나오도록 수정`)
- 상세 페이지 메뉴에서 가격 정보가 없어도 정상적으로 표시되도록 예외 처리 (`fix: 상세 페이지 메뉴 가격 없어도 정상적으로 나오도록 수정`)

## 🔗 관련 이슈

Closes #39 


## 🧪 테스트 (Optional)

- [ ] 주소, 전화번호, 메뉴 가격 정보가 없는 상세 페이지에서 UI가 정상적으로 표시되는지 확인
- [ ] 타입 정의가 백엔드와 일치하는지 확인

## 🚨 주의사항 (Optional)

- 타입 변경에 따라 기존 데이터와의 호환성에 유의해 주세요.
