### PR TITLE
Fix/#62 상세 페이지 메뉴는 있어도 가격이 없는 부분 예외처리

### DIFF
--- a/src/features/place/components/place-basic-info/PlaceBasicInfo.tsx
+++ b/src/features/place/components/place-basic-info/PlaceBasicInfo.tsx
@@ -26,8 +26,8 @@ export function PlaceBasicInfo({ placeBasicInfo }: PlaceBasicInfoProps) {
       </div>
       <h1 className="heading-1 mb-4">{name}</h1>
       <div className="mb-6">
-        <p className="body-text mb-2 text-gray-600">{address}</p>
-        <p className="body-text mb-2 text-gray-600">{phone}</p>
+        {address && <p className="body-text mb-2 text-gray-600">{address}</p>}
+        {phone && <p className="body-text mb-2 text-gray-600">{phone}</p>}
         <div className="mb-4 flex gap-2">
           {keywords.map((keyword) => (
             <span

--- a/src/features/place/components/place-menu/PlaceMenu.tsx
+++ b/src/features/place/components/place-menu/PlaceMenu.tsx
@@ -26,9 +26,11 @@ export function PlaceMenu({ menu }: PlaceMenuProps) {
         {visibleMenu.map((item) => (
           <div key={item.name} className="flex items-center justify-between">
             <span className="body-text text-gray-800">{item.name}</span>
-            <span className="body-text text-gray-600">
-              {item.price.toLocaleString()}원
-            </span>
+            {item.price && (
+              <span className="body-text text-gray-600">
+                {item.price.toLocaleString()}원
+              </span>
+            )}
           </div>
         ))}
       </div>

--- a/src/features/place/types/place.ts
+++ b/src/features/place/types/place.ts
@@ -20,16 +20,16 @@ export interface Place {
 export interface PlaceDetail {
   id: number;
   name: string;
-  address: string;
-  thumbnail: string;
+  address: string | null;
+  thumbnail: string | null;
   location: {
     coordinates: [number, number];
     type: string;
   };
   keywords: string[];
   description: string;
-  phone: string;
-  menu: Menu[];
+  phone: string | null;
+  menu?: Menu[];
   opening_hours: OpenHours;
 }
 
@@ -49,5 +49,5 @@ export interface OpenHours {
 }
 export interface Menu {
   name: string;
-  price: number;
+  price: number | null;
 }


### PR DESCRIPTION
## 📝 PR 개요

이 PR은 백엔드와의 타입 통일 및 상세 페이지에서 일부 정보가 없을 때도 정상적으로 동작하도록 UI/UX를 개선합니다.

## 🔍 변경사항

- 백엔드와 프론트엔드 타입 정의를 통일하여 데이터 일관성을 확보 (`refactor: 백엔드와 타입 통일`)
- 상세 페이지에서 주소, 전화번호 정보가 없어도 정상적으로 렌더링되도록 수정 (`fix: 상세 페이지 주소, 폰 번호 정보 없어도 정상적으로 나오도록 수정`)
- 상세 페이지 메뉴에서 가격 정보가 없어도 정상적으로 표시되도록 예외 처리 (`fix: 상세 페이지 메뉴 가격 없어도 정상적으로 나오도록 수정`)

## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->

## 📸 스크린샷 (Optional)

<!-- UI 변경사항이 있거나 필요한 경우 스크린샷 추가 -->

## 🧪 테스트 (Optional)

- [ ] 주소, 전화번호, 메뉴 가격 정보가 없는 상세 페이지에서 UI가 정상적으로 표시되는지 확인
- [ ] 타입 정의가 백엔드와 일치하는지 확인

## 🚨 주의사항 (Optional)

- 타입 변경에 따라 기존 데이터와의 호환성에 유의해 주세요.
