### PR TITLE
Style/#76 가장 작은 뷰포트 높이 기준으로 계산하도록 수정 (모바일 주소창, 툴바 고려)

### DIFF
--- a/src/app/(auth)/oauth/kakao/callback/page.tsx
+++ b/src/app/(auth)/oauth/kakao/callback/page.tsx
@@ -14,7 +14,7 @@ export default function KakaoCallbackPage() {
         flexDirection: 'column',
         justifyContent: 'center',
         alignItems: 'center',
-        height: '100vh',
+        height: '100svh',
         padding: '20px',
         textAlign: 'center',
       }}

--- a/src/app/(main)/moments/page.tsx
+++ b/src/app/(main)/moments/page.tsx
@@ -4,7 +4,7 @@ export default function Moments() {
   return (
     <>
       <Header title="다이어리" />
-      <div className="flex h-[calc(100vh-64px)] items-center justify-center text-center text-gray-500">
+      <div className="flex h-[calc(100svh-64px)] items-center justify-center text-center text-gray-500">
         곧 여러분을 찾아갈 새로운 기능을 준비 중이에요!
       </div>
     </>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,7 +52,7 @@
 
 /* 웹에서 모바일 사이즈로 보여주기 */
 body {
-  min-height: 100vh;
+  min-height: 100svh;
   width: 100%;
   display: flex;
   justify-content: center;
@@ -70,8 +70,9 @@ body {
   width: 100%;
   max-width: 430px;
   min-width: 375px;
-  min-height: 100vh;
-  height: 100vh;
+  min-height: 100svh;
+  height: calc(var(--vh, 1vh) * 100);
+  height: 100svh;
   background: var(--background);
   position: relative;
   overflow-x: hidden;

--- a/src/features/place/components/map/Map.tsx
+++ b/src/features/place/components/map/Map.tsx
@@ -63,7 +63,7 @@ export function Map({ places }: MapProps) {
       <div
         id="map"
         className="absolute inset-0 z-0 h-full w-full"
-        style={{ minHeight: '100vh' }}
+        style={{ minHeight: '100svh' }}
       />
       <PlaceBottomSheet
         isOpen={isBottomSheetOpen}

--- a/src/features/place/components/place-list/PlaceList.tsx
+++ b/src/features/place/components/place-list/PlaceList.tsx
@@ -38,7 +38,7 @@ export function PlaceList({ places }: PlaceListProps) {
       <Drawer.Portal>
         <Drawer.Content
           className="fixed right-0 bottom-0 left-0 z-50 mx-auto flex h-full max-w-[430px] flex-col rounded-t-2xl border-t bg-white shadow-lg"
-          style={{ maxHeight: '100dvh' }}
+          style={{ maxHeight: '100svh' }}
         >
           <div className="mx-auto mt-4 h-1.5 w-12 rounded-full bg-zinc-300" />
           <Drawer.Title className="hidden">추천 장소 목록</Drawer.Title>


### PR DESCRIPTION

## 📝 PR 개요

모바일 환경에서 주소창, 툴바 등 브라우저 UI에 의해 뷰포트 높이가 변동되는 문제를 해결하기 위해  
가장 작은 뷰포트 높이(svh)를 기준으로 레이아웃이 계산되도록 수정하였습니다.


## 🔍 변경사항

- CSS height 단위를 기존 `vh`에서 `svh`로 변경
- 모바일 브라우저에서 주소창, 툴바 등 UI가 보이거나 숨겨질 때도 레이아웃이 안정적으로 유지됨


## 주요 변경사항

- 주요 레이아웃 컴포넌트의 높이 단위를 `svh`로 적용
- 모바일 환경에서 레이아웃 점프 및 흔들림 현상 개선



## 🧪 테스트 (Optional)

- [ ] 모바일 브라우저에서 주소창/툴바가 보이거나 숨겨질 때 레이아웃이 안정적으로 유지되는지 확인
- [ ] 다양한 기기에서 높이 단위 적용이 정상적으로 동작하는지 확인


## 🚨 주의사항 (Optional)

- 일부 구형 브라우저에서는 `svh` 단위가 지원되지 않을 수 있으니, 브라우저 호환성 확인 필요
