### PR TITLE
Feat/#73 피드백 버튼 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-import { Toaster } from '@/shared/components';
+import { FeedbackButton, Toaster } from '@/shared/components';
 import { pretendard } from '@/shared/fonts';
 import { QueryProvider } from '@/shared/providers';
 
@@ -33,6 +33,7 @@ export default function RootLayout({
             </main>
           </div>
         </QueryProvider>
+        <FeedbackButton />
       </body>
     </html>
   );

--- a/src/shared/components/feedback-button/FeedbackButton.tsx
+++ b/src/shared/components/feedback-button/FeedbackButton.tsx
@@ -1,0 +1,20 @@
+const FEEDBACK_URL =
+  'https://docs.google.com/forms/d/e/1FAIpQLSdgU6kRLmIC4FM6NjRGKYdgpiq8TndMRToWrQ5Tt5g73SNq4A/viewform';
+
+export function FeedbackButton() {
+  return (
+    <a
+      href={FEEDBACK_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="피드백 남기러 가기"
+      className="fixed right-4 bottom-6 z-50 hidden items-center gap-2 rounded-full bg-rose-200 px-6 py-3 font-medium text-[#333] shadow-xl transition-all duration-200 hover:scale-105 hover:bg-rose-300 hover:shadow-2xl focus:ring-4 focus:ring-rose-200 focus:outline-none active:scale-100 sm:flex sm:px-4 sm:py-4"
+      style={{ minWidth: 56, minHeight: 56 }}
+    >
+      <span className="text-2xl" role="img" aria-label="피드백">
+        💌
+      </span>
+      <span className="hidden sm:inline">피드백 남기러 가기</span>
+    </a>
+  );
+}

--- a/src/shared/components/feedback-button/index.ts
+++ b/src/shared/components/feedback-button/index.ts
@@ -1,0 +1,1 @@
+export * from './FeedbackButton';

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -9,3 +9,4 @@ export * from './form';
 export * from './button';
 export * from './card';
 export * from './checkbox';
+export * from './feedback-button';


### PR DESCRIPTION


## 📝 PR 개요

마이페이지 하단에 고정된 피드백 버튼 컴포넌트를 추가하였습니다.  
사용자는 버튼을 클릭하여 구글 폼을 통해 피드백을 남길 수 있습니다.


## 🔍 변경사항

- 오른쪽 하단에 고정된 동그란 피드백 버튼 컴포넌트 추가
- 연핑크 단색 배경, 하트편지(💌) 이모지, "피드백 남기러 가기" 텍스트 적용
- 모바일 환경에서는 버튼이 보이지 않도록 처리
- 버튼 클릭 시 새 탭에서 구글 폼으로 이동


## 주요 변경사항

- `FeedbackButton` 컴포넌트 생성 및 스타일링
- 접근성(aria-label) 및 반응형 대응

## 🔗 관련 이슈

- Closes #73 


## 📸 스크린샷 (Optional)

<img width="1422" alt="image" src="https://github.com/user-attachments/assets/a5711043-0c8c-4bf5-a261-ce52229124e8" />


## 🧪 테스트 (Optional)

- [ ] 데스크탑/태블릿 환경에서 버튼이 오른쪽 하단에 잘 노출되는지 확인
- [ ] 버튼 클릭 시 구글 폼이 새 탭에서 열리는지 확인
- [ ] 모바일 환경에서 버튼이 보이지 않는지 확인


## 🚨 주의사항 (Optional)

- 버튼 색상 및 위치는 디자인 가이드에 따라 추후 변경될 수 있음
- 구글 폼 URL이 변경될 경우 컴포넌트 내 URL도 함께 수정 필요
