### PR TITLE
Refactor/#67 정보 동의 페이지 컴포넌트 및 custom hook 으로 상태 관리

### DIFF
--- a/src/app/(auth)/auth/consent/page.tsx
+++ b/src/app/(auth)/auth/consent/page.tsx
@@ -1,34 +1,17 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { LocationConsent, PrivacyConsent, useConsent } from '@/features/user';
+import { Button, Checkbox } from '@/shared/components';
 
-import { postAgreement } from '@/features/user';
-import { Button, Card, Checkbox } from '@/shared/components';
-
-export default function Consent() {
-  const router = useRouter();
-  const [privacyConsent, setPrivacyConsent] = useState(false);
-  const [locationConsent, setLocationConsent] = useState(false);
-
-  const handleAllConsent = () => {
-    const newValue = !(privacyConsent && locationConsent);
-    setPrivacyConsent(newValue);
-    setLocationConsent(newValue);
-  };
-
-  const handleAgreement = async () => {
-    try {
-      await postAgreement({
-        location_agreed: true,
-        privacy_agreed: true,
-      });
-
-      router.push('/auth/signup');
-    } catch (error) {
-      console.error(error);
-    }
-  };
+export default function ConsentPage() {
+  const {
+    privacyConsent,
+    locationConsent,
+    handleAllConsent,
+    handleAgreement,
+    setPrivacyConsent,
+    setLocationConsent,
+  } = useConsent();
 
   return (
     <div className="container mx-auto max-w-3xl px-4 py-8">
@@ -37,93 +20,14 @@ export default function Consent() {
       </h1>
 
       <div className="space-y-6">
-        <div>
-          <Card className="p-6">
-            <div className="scrollbar-hide h-[200px] overflow-y-auto pr-4">
-              <h2 className="heading-2 mb-4">
-                제1조 (개인정보 수집 항목 및 이용 목적)
-              </h2>
-              <p className="body-text mb-4">
-                회사는 다음과 같은 개인정보를 수집하고 있습니다.
-              </p>
-
-              <div className="mb-6">
-                <h3 className="heading-3 mb-2">1. 필수항목</h3>
-                <ul className="body-text list-disc space-y-2 pl-6">
-                  <li>이메일 주소: 회원식별 및 로그인</li>
-                  <li>닉네임: 서비스 이용</li>
-                  <li>프로필 이미지: 서비스 이용</li>
-                </ul>
-              </div>
-
-              <div className="mb-6">
-                <h3 className="heading-3 mb-2">2. 선택항목</h3>
-                <ul className="body-text list-disc space-y-2 pl-6">
-                  <li>관심사: 맞춤 서비스 제공</li>
-                  <li>연령대: 맞춤 콘텐츠 제공</li>
-                </ul>
-              </div>
-            </div>
-          </Card>
-          <div className="mt-4 flex items-center space-x-2">
-            <Checkbox
-              id="privacy"
-              checked={privacyConsent}
-              onCheckedChange={(checked) =>
-                setPrivacyConsent(checked as boolean)
-              }
-            />
-            <label htmlFor="privacy" className="body-text">
-              [필수] 개인정보 수집 및 이용 동의
-            </label>
-          </div>
-        </div>
-
-        <div>
-          <Card className="p-6">
-            <div className="scrollbar-hide h-[200px] overflow-y-auto pr-4">
-              <h2 className="heading-2 mb-4">위치기반 서비스 이용 약관</h2>
-
-              <div className="mb-6">
-                <h3 className="heading-3 mb-2">제1조 (목적)</h3>
-                <p className="body-text">
-                  본 약관은 서비스의 위치기반 서비스 제공에 관한 사항을
-                  규정합니다.
-                </p>
-              </div>
-
-              <div className="mb-6">
-                <h3 className="heading-3 mb-2">제2조 (위치정보 수집 방법)</h3>
-                <ul className="body-text list-disc space-y-2 pl-6">
-                  <li>GPS: 사용자 단말기의 위치정보</li>
-                  <li>Wi-Fi: 무선망을 통한 위치정보</li>
-                  <li>기지국: 이동통신 기지국 위치정보</li>
-                </ul>
-              </div>
-
-              <div className="mb-6">
-                <h3 className="heading-3 mb-2">제3조 (위치정보 이용목적)</h3>
-                <ul className="body-text list-disc space-y-2 pl-6">
-                  <li>현재 위치 기반 장소 추천 서비스 제공</li>
-                  <li>위치 기반 맞춤 콘텐츠 제공</li>
-                </ul>
-              </div>
-            </div>
-          </Card>
-          <div className="mt-4 flex items-center space-x-2">
-            <Checkbox
-              id="location"
-              checked={locationConsent}
-              onCheckedChange={(checked) =>
-                setLocationConsent(checked as boolean)
-              }
-            />
-            <label htmlFor="location" className="body-text">
-              [필수] 위치기반 서비스 이용 약관 동의
-            </label>
-          </div>
-        </div>
-
+        <PrivacyConsent
+          checked={privacyConsent}
+          onCheckedChange={setPrivacyConsent}
+        />
+        <LocationConsent
+          checked={locationConsent}
+          onCheckedChange={setLocationConsent}
+        />
         <div className="flex items-center space-x-2">
           <Checkbox
             id="all"

--- a/src/features/user/components/consent/ConsentCard.tsx
+++ b/src/features/user/components/consent/ConsentCard.tsx
@@ -1,0 +1,39 @@
+import { PropsWithChildren } from 'react';
+
+import { Card, Checkbox } from '@/shared/components';
+
+export interface ConsentCardProps extends PropsWithChildren {
+  title: string;
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+export function ConsentCard({
+  title,
+  label,
+  checked,
+  children,
+  onCheckedChange,
+}: ConsentCardProps) {
+  return (
+    <div>
+      <Card className="p-6">
+        <div className="scrollbar-hide h-[200px] overflow-y-auto pr-4">
+          <h2 className="heading-2 mb-4">{title}</h2>
+          {children}
+        </div>
+      </Card>
+      <div className="mt-4 flex items-center space-x-2">
+        <Checkbox
+          id={label}
+          checked={checked}
+          onCheckedChange={onCheckedChange}
+        />
+        <label htmlFor={label} className="body-text">
+          {label}
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/features/user/components/consent/LocationConsent.tsx
+++ b/src/features/user/components/consent/LocationConsent.tsx
@@ -1,0 +1,38 @@
+import { ConsentCard } from './ConsentCard';
+
+export const LocationConsent = ({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) => (
+  <ConsentCard
+    title="위치기반 서비스 이용 약관"
+    checked={checked}
+    onCheckedChange={onCheckedChange}
+    label="[필수] 위치기반 서비스 이용 약관 동의"
+  >
+    <div className="mb-6">
+      <h3 className="heading-3 mb-2">제1조 (목적)</h3>
+      <p className="body-text">
+        본 약관은 서비스의 위치기반 서비스 제공에 관한 사항을 규정합니다.
+      </p>
+    </div>
+    <div className="mb-6">
+      <h3 className="heading-3 mb-2">제2조 (위치정보 수집 방법)</h3>
+      <ul className="body-text list-disc space-y-2 pl-6">
+        <li>GPS: 사용자 단말기의 위치정보</li>
+        <li>Wi-Fi: 무선망을 통한 위치정보</li>
+        <li>기지국: 이동통신 기지국 위치정보</li>
+      </ul>
+    </div>
+    <div className="mb-6">
+      <h3 className="heading-3 mb-2">제3조 (위치정보 이용목적)</h3>
+      <ul className="body-text list-disc space-y-2 pl-6">
+        <li>현재 위치 기반 장소 추천 서비스 제공</li>
+        <li>위치 기반 맞춤 콘텐츠 제공</li>
+      </ul>
+    </div>
+  </ConsentCard>
+);

--- a/src/features/user/components/consent/PrivacyConsent.tsx
+++ b/src/features/user/components/consent/PrivacyConsent.tsx
@@ -1,0 +1,35 @@
+import { ConsentCard } from './ConsentCard';
+
+export const PrivacyConsent = ({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) => (
+  <ConsentCard
+    title="제1조 (개인정보 수집 항목 및 이용 목적)"
+    checked={checked}
+    onCheckedChange={onCheckedChange}
+    label="[필수] 개인정보 수집 및 이용 동의"
+  >
+    <p className="body-text mb-4">
+      회사는 다음과 같은 개인정보를 수집하고 있습니다.
+    </p>
+    <div className="mb-6">
+      <h3 className="heading-3 mb-2">1. 필수항목</h3>
+      <ul className="body-text list-disc space-y-2 pl-6">
+        <li>이메일 주소: 회원식별 및 로그인</li>
+        <li>닉네임: 서비스 이용</li>
+        <li>프로필 이미지: 서비스 이용</li>
+      </ul>
+    </div>
+    <div className="mb-6">
+      <h3 className="heading-3 mb-2">2. 선택항목</h3>
+      <ul className="body-text list-disc space-y-2 pl-6">
+        <li>관심사: 맞춤 서비스 제공</li>
+        <li>연령대: 맞춤 콘텐츠 제공</li>
+      </ul>
+    </div>
+  </ConsentCard>
+);

--- a/src/features/user/components/consent/index.ts
+++ b/src/features/user/components/consent/index.ts
@@ -1,0 +1,2 @@
+export * from './LocationConsent';
+export * from './PrivacyConsent';

--- a/src/features/user/components/index.ts
+++ b/src/features/user/components/index.ts
@@ -1,3 +1,4 @@
 export * from './profile';
 export * from './profile-form';
 export * from './delete-account';
+export * from './consent';

--- a/src/features/user/hooks/index.ts
+++ b/src/features/user/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useUser';
+export * from './useConsent';

--- a/src/features/user/hooks/useConsent.ts
+++ b/src/features/user/hooks/useConsent.ts
@@ -1,0 +1,38 @@
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { postAgreement } from '../api';
+
+export const useConsent = () => {
+  const router = useRouter();
+  const [privacyConsent, setPrivacyConsent] = useState(false);
+  const [locationConsent, setLocationConsent] = useState(false);
+
+  const handleAllConsent = () => {
+    const newValue = !(privacyConsent && locationConsent);
+    setPrivacyConsent(newValue);
+    setLocationConsent(newValue);
+  };
+
+  const handleAgreement = async () => {
+    try {
+      await postAgreement({
+        location_agreed: true,
+        privacy_agreed: true,
+      });
+
+      router.push('/auth/signup');
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return {
+    privacyConsent,
+    setPrivacyConsent,
+    locationConsent,
+    setLocationConsent,
+    handleAllConsent,
+    handleAgreement,
+  };
+};


### PR DESCRIPTION
# 📝 PR 개요

Consent 페이지의 컴포넌트 구조를 개선하여 코드의 재사용성과 유지보수성을 향상시켰습니다. 커스텀 훅을 도입하여 상태 관리 로직을 분리하고, 공통 컴포넌트를 만들어 UI 일관성을 유지했습니다.

## 🔍 변경사항

- Consent 페이지 컴포넌트 분리
  - `ConsentCard`: 공통 카드 UI 컴포넌트
  - `PrivacyConsent`: 개인정보 수집 동의 컴포넌트
  - `LocationConsent`: 위치기반 서비스 동의 컴포넌트

- 커스텀 훅 도입
  - `useConsent`: 동의 상태 관리 및 API 호출 로직 분리
  - 체크박스 상태 관리
  - 동의 API 호출 및 라우팅 처리

## 🔗 관련 이슈

- Closes #67 

## 🧪 테스트

- [ ] 개인정보 수집 동의 체크박스 동작 확인
- [ ] 위치기반 서비스 동의 체크박스 동작 확인
- [ ] 모두 동의 기능 정상 동작 확인
- [ ] 동의 후 다음 페이지 이동 확인
- [ ] API 호출 정상 동작 확인

## 🚨 주의사항

- 기존 기능과 동일하게 동작하는지 확인이 필요합니다.
- 스타일링이 기존과 동일하게 유지되었는지 확인해주세요.
- 체크박스 상태 변경 시 모든 동의 체크박스가 정상적으로 동작하는지 확인해주세요.