### PR TITLE
Feat/#103 로컬 환경에서 백엔드 dev 바라보도록 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ next-env.d.ts
 
 # husky
 .husky/_
+
+certificates

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@8.15.4",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev -H test.dev.dolpin.site --turbopack --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/features/user/api/getOAuthRedirectUrl.ts
+++ b/src/features/user/api/getOAuthRedirectUrl.ts
@@ -1,11 +1,15 @@
 import { OAuthRedirectResponse } from '../types';
+import { getRedirectUri } from '../utils';
 
 import { fetchApi } from '@/shared/lib/fetchApi';
 
 export async function getOAuthRedirectUrl(): Promise<OAuthRedirectResponse> {
   try {
-    const response =
-      await fetchApi<OAuthRedirectResponse>('/api/v1/auth/oauth');
+    const redirectUri = getRedirectUri();
+
+    const response = await fetchApi<OAuthRedirectResponse>(
+      `/api/v1/auth/oauth${redirectUri ? `?redirect_uri=${redirectUri}` : ''}`,
+    );
     return response;
   } catch (error) {
     console.error(error);

--- a/src/features/user/api/issueAuthTokens.ts
+++ b/src/features/user/api/issueAuthTokens.ts
@@ -1,15 +1,21 @@
 import { AuthTokens, TokensRequestBody } from '../types';
+import { getRedirectUri } from '../utils';
 
 import { fetchApi, FetchApiError } from '@/shared/lib/fetchApi';
 
 export async function issueAuthTokens(
   body: TokensRequestBody,
 ): Promise<AuthTokens> {
+  const redirectUri = getRedirectUri();
+
   try {
-    const response = await fetchApi<AuthTokens>('/api/v1/auth/tokens', {
-      method: 'POST',
-      body: JSON.stringify(body),
-    });
+    const response = await fetchApi<AuthTokens>(
+      `/api/v1/auth/tokens${redirectUri ? `?redirect_uri=${redirectUri}` : ''}`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body),
+      },
+    );
 
     return response;
   } catch (error) {

--- a/src/features/user/utils/getRedirectUri.ts
+++ b/src/features/user/utils/getRedirectUri.ts
@@ -1,0 +1,6 @@
+export const getRedirectUri = () => {
+  if (process.env.NODE_ENV === 'development') {
+    return process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI;
+  }
+  return null;
+};

--- a/src/features/user/utils/index.ts
+++ b/src/features/user/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './getRedirectUri';


### PR DESCRIPTION
# 로컬 환경에서 백엔드 dev 연동 설정

## 📝 PR 개요
로컬 개발 환경에서 백엔드 dev 서버와의 연동을 위한 설정을 추가합니다. 이를 통해 로컬에서 개발 시 백엔드 dev 서버의 API를 사용할 수 있도록 합니다.

## 🔍 변경사항

- OAuth 리다이렉트 URI 설정
  - 로컬 환경에서 `NEXT_PUBLIC_OAUTH_REDIRECT_URI` 환경 변수 사용

- HTTPS 및 도메인 설정
  - `test.dev.dolpin.site`로 호스팅되도록 설정
  - HTTPS 프로토콜 사용 설정

- 보안 설정
  - certificates 파일을 gitignore에 추가
  - 민감한 인증 정보 보호

## 🔗 관련 이슈
- Closes #103 

## 🧪 테스트

- [ ] 로컬 환경에서 백엔드 dev API 호출 테스트
  - API 요청이 정상적으로 전달되는지 확인
  - 응답이 정상적으로 수신되는지 확인

- [ ] OAuth 로그인 테스트
  - 로컬 환경에서 카카오 로그인 정상 작동 확인
  - 리다이렉트 URI가 정상적으로 처리되는지 확인

- [ ] HTTPS 연결 테스트
  - `test.dev.dolpin.site` 도메인으로 정상 접속 확인
  - HTTPS 프로토콜 정상 작동 확인

## 🚨 주의사항

1. **환경 변수 설정**
   - 로컬 개발 시 `.env` 파일에 `NEXT_PUBLIC_OAUTH_REDIRECT_URI` 설정 필요
   - 환경 변수가 없을 경우 백엔드에서 설정 된 기본값 사용

2. **보안**
   - certificates 파일은 git에 커밋하지 않기
   - 민감한 인증 정보는 환경 변수로 관리

3. **백엔드 연동**
   - 백엔드 dev 서버가 정상적으로 동작 중인지 확인
   - CORS 설정이 올바른지 확인

## 📋 추가 정보

### 환경 변수 설정 예시
```env
# .env.development
NEXT_PUBLIC_OAUTH_REDIRECT_URI=http://localhost:3000/oauth/kakao/callback
```