### PR TITLE
Fix/#85 vaul 바텀시트 클릭 시, 외부 input 클릭 안되는 라이브러리 문제 다운그레이드로 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-hook-form": "^7.56.2",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.2.0",
-    "vaul": "^1.1.2",
+    "vaul": "0.8.9",
     "zod": "^3.24.3",
     "zustand": "^5.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ dependencies:
     specifier: ^3.2.0
     version: 3.2.0
   vaul:
-    specifier: ^1.1.2
-    version: 1.1.2(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+    specifier: 0.8.9
+    version: 0.8.9(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
   zod:
     specifier: ^3.24.3
     version: 3.24.3
@@ -3876,11 +3876,11 @@ packages:
       tslib: 2.8.1
     dev: false
 
-  /vaul@1.1.2(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
-    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+  /vaul@0.8.9(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-gpmtmZRWDPP6niQh14JfRIFUYZVyfvAWyA/7rUINOfNlO/2K7uEvI5rLXEXkxZIRFyUZj+TPHLFMirkegPHjrw==}
     peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
       '@radix-ui/react-dialog': 1.1.11(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
       react: 19.1.0


### PR DESCRIPTION

## 📝 PR 개요
vaul 바텀시트 사용 시 발생하는 외부 input 클릭 불가 문제를 해결하기 위해 vaul 라이브러리를 v0.8.9 버전으로 다운그레이드했습니다.

## 🔍 변경사항
- vaul 라이브러리 버전을 v0.8.9로 다운그레이드
- `package.json`의 vaul 의존성 버전 업데이트

## 관련 이슈
Closes #85

## 🧪 테스트
- [x] 바텀시트 열린 상태에서 SearchResultBar의 input 클릭 테스트
- [x] 바텀시트 열린 상태에서 뒤로가기/검색 버튼 클릭 테스트
- [x] 바텀시트 닫힌 상태에서 input 클릭 테스트

## 🚨 주의사항
- vaul 라이브러리의 최신 버전에서 발생하는 알려진 이슈였으며, v0.8.9 버전으로 다운그레이드하여 해결했습니다.
- 향후 vaul 라이브러리 업데이트 시 이 문제가 해결되었는지 확인이 필요합니다.


## 🔍 문제 해결 과정

### 1. 문제 상황
- vaul 바텀시트 사용 시, 바텀시트가 열린 후에는 상단의 SearchResultBar 내 input 창 클릭이 안 됨
- 바텀시트 좌우의 뒤로가기 버튼과 검색 버튼은 정상 동작
- vaul 바텀시트를 사용하지 않으면 input 창 클릭이 정상 동작

### 2. 원인 분석
- vaul 라이브러리의 포커스 트래핑(focus trapping) 또는 오버레이 문제로 추정
- z-index 문제나 레이어 씌워짐은 육안으로 확인했을 때 아닌 것으로 판단
- modal={false} 옵션을 설정했음에도 input만 상호작용 불가

### 3. 해결 방법
- vaul 라이브러리를 v0.8.9 버전으로 다운그레이드
- [vaul 이슈 #534](https://github.com/emilkowalski/vaul/issues/534)에서 확인된 알려진 문제였음
