### PR TITLE
Style/#109 PlaceList 컴포넌트의 UI/UX를 개선, 레이아웃 구조 개선

### DIFF
--- a/src/app/(main)/(places)/search/layout.tsx
+++ b/src/app/(main)/(places)/search/layout.tsx
@@ -1,5 +1,7 @@
 import { Suspense } from 'react';
 
+import { SearchResultBar } from '@/features/place';
+
 export default function PlacesLayout({
   children,
 }: {
@@ -7,6 +9,11 @@ export default function PlacesLayout({
 }) {
   return (
     <div className="flex h-full w-full flex-col">
+      <Suspense>
+        <div className="absolute top-0 left-0 z-9999 flex w-full flex-col gap-5">
+          <SearchResultBar />
+        </div>
+      </Suspense>
       <Suspense
         fallback={
           <div className="flex h-full w-full items-center justify-center">

--- a/src/app/(main)/(places)/search/layout.tsx
+++ b/src/app/(main)/(places)/search/layout.tsx
@@ -10,7 +10,7 @@ export default function PlacesLayout({
   return (
     <div className="flex h-full w-full flex-col">
       <Suspense>
-        <div className="absolute top-0 left-0 z-9999 flex w-full flex-col gap-5">
+        <div className="absolute top-0 left-0 z-40 flex w-full flex-col gap-5">
           <SearchResultBar />
         </div>
       </Suspense>

--- a/src/app/(main)/(places)/search/page.tsx
+++ b/src/app/(main)/(places)/search/page.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from 'next/navigation';
 import {
   Map,
   Place,
-  PlaceList,
+  PlaceListBottomSheet,
   searchPlaces,
   SearchPlacesResponse,
 } from '@/features/place';
@@ -53,7 +53,7 @@ export default function SearchPage() {
       {places.length > 0 ? (
         <>
           <Map places={places} />
-          <PlaceList places={places} />
+          <PlaceListBottomSheet places={places} />
         </>
       ) : (
         <div className="flex h-full w-full items-center justify-center">

--- a/src/app/(main)/(places)/search/page.tsx
+++ b/src/app/(main)/(places)/search/page.tsx
@@ -2,7 +2,6 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
-import { Suspense } from 'react';
 
 import {
   Map,
@@ -10,7 +9,6 @@ import {
   PlaceList,
   searchPlaces,
   SearchPlacesResponse,
-  SearchResultBar,
 } from '@/features/place';
 
 export default function SearchPage() {
@@ -52,11 +50,6 @@ export default function SearchPage() {
 
   return (
     <div className="relative h-full w-full">
-      <div className="absolute top-0 left-0 z-10 flex w-full flex-col gap-5">
-        <Suspense>
-          <SearchResultBar />
-        </Suspense>
-      </div>
       {places.length > 0 ? (
         <>
           <Map places={places} />

--- a/src/features/place/components/index.ts
+++ b/src/features/place/components/index.ts
@@ -4,7 +4,7 @@ export * from './category-list';
 export * from './keyword-list';
 export * from './place-bottom-sheet';
 export * from './search-result-bar';
-export * from './place-list';
+export * from './place-list-bottom-sheet';
 export * from './place-menu';
 export * from './place-open-hours';
 export * from './place-basic-info';

--- a/src/features/place/components/place-bottom-sheet/PlaceBottomSheet.tsx
+++ b/src/features/place/components/place-bottom-sheet/PlaceBottomSheet.tsx
@@ -23,7 +23,7 @@ export function PlaceBottomSheet({
   return (
     <Drawer.Root open={isOpen} onOpenChange={onOpenChange}>
       <Drawer.Portal>
-        <Drawer.Overlay className="fixed inset-0 z-40 bg-black/40" />
+        <Drawer.Overlay className="fixed inset-0 z-50 bg-black/40" />
         <Drawer.Content className="fixed right-0 bottom-0 left-0 z-50 mx-auto flex h-fit w-full max-w-[430px] flex-col rounded-t-[10px] bg-gray-100 outline-none">
           <div className="flex-1 rounded-t-[10px] bg-white p-4">
             <div className="max-w-m10 mx-auto mt-7">

--- a/src/features/place/components/place-bottom-sheet/PlaceBottomSheet.tsx
+++ b/src/features/place/components/place-bottom-sheet/PlaceBottomSheet.tsx
@@ -26,8 +26,7 @@ export function PlaceBottomSheet({
         <Drawer.Overlay className="fixed inset-0 z-40 bg-black/40" />
         <Drawer.Content className="fixed right-0 bottom-0 left-0 z-50 mx-auto flex h-fit w-full max-w-[430px] flex-col rounded-t-[10px] bg-gray-100 outline-none">
           <div className="flex-1 rounded-t-[10px] bg-white p-4">
-            <div className="mx-auto mb-3 h-1.5 w-12 flex-shrink-0 rounded-full bg-gray-300" />
-            <div className="mx-auto max-w-md">
+            <div className="max-w-m10 mx-auto mt-7">
               <div className="relative">
                 <Drawer.Title className="sr-only">{place.name}</Drawer.Title>
                 <Drawer.Description className="sr-only">

--- a/src/features/place/components/place-list-bottom-sheet/PlaceListBottomSheet.tsx
+++ b/src/features/place/components/place-list-bottom-sheet/PlaceListBottomSheet.tsx
@@ -10,7 +10,7 @@ export interface PlaceListProps {
   places: Place[];
 }
 
-export function PlaceList({ places }: PlaceListProps) {
+export function PlaceListBottomSheet({ places }: PlaceListProps) {
   const snapPoints = ['200px', '355px', 1];
   const [snap, setSnap] = useState<number | string | null>(snapPoints[0]);
 
@@ -24,7 +24,7 @@ export function PlaceList({ places }: PlaceListProps) {
     >
       <Drawer.Portal>
         <Drawer.Content
-          className="fixed right-0 bottom-0 left-0 z-10 mx-auto flex h-full max-w-[430px] flex-col rounded-t-2xl border-t bg-white shadow-lg"
+          className="fixed right-0 bottom-0 left-0 z-10 mx-auto flex h-full max-w-[430px] flex-col rounded-t-2xl border-t bg-white shadow-lg outline-none"
           style={{ maxHeight: 'calc(100svh - 60px)' }}
         >
           <div className="mx-auto mt-4 h-1.5 w-12 rounded-full bg-zinc-300" />

--- a/src/features/place/components/place-list-bottom-sheet/index.ts
+++ b/src/features/place/components/place-list-bottom-sheet/index.ts
@@ -1,0 +1,1 @@
+export * from './PlaceListBottomSheet';

--- a/src/features/place/components/place-list/PlaceList.tsx
+++ b/src/features/place/components/place-list/PlaceList.tsx
@@ -24,8 +24,8 @@ export function PlaceList({ places }: PlaceListProps) {
     >
       <Drawer.Portal>
         <Drawer.Content
-          className="fixed right-0 bottom-0 left-0 z-50 mx-auto flex h-full max-w-[430px] flex-col rounded-t-2xl border-t bg-white shadow-lg"
-          style={{ maxHeight: '100svh' }}
+          className="fixed right-0 bottom-0 left-0 z-10 mx-auto flex h-full max-w-[430px] flex-col rounded-t-2xl border-t bg-white shadow-lg"
+          style={{ maxHeight: 'calc(100svh - 60px)' }}
         >
           <div className="mx-auto mt-4 h-1.5 w-12 rounded-full bg-zinc-300" />
           <Drawer.Title className="hidden">추천 장소 목록</Drawer.Title>

--- a/src/features/place/components/place-list/PlaceList.tsx
+++ b/src/features/place/components/place-list/PlaceList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { Drawer } from 'vaul';
 
 import { Place } from '../../types';
@@ -12,28 +12,15 @@ export interface PlaceListProps {
 
 export function PlaceList({ places }: PlaceListProps) {
   const snapPoints = ['200px', '355px', 1];
-  const minSnap = snapPoints[0];
-
-  const [isOpen, setIsOpen] = useState(true);
-  const [snap, setSnap] = useState<string | number | null>(minSnap);
-  const contentRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (isOpen && contentRef.current) {
-      const firstButton = contentRef.current.querySelector('button');
-      firstButton?.focus();
-    }
-  }, [isOpen]);
+  const [snap, setSnap] = useState<number | string | null>(snapPoints[0]);
 
   return (
     <Drawer.Root
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (open) setIsOpen(true);
-      }}
+      open={true}
       snapPoints={snapPoints}
       activeSnapPoint={snap}
       setActiveSnapPoint={setSnap}
+      modal={false}
     >
       <Drawer.Portal>
         <Drawer.Content

--- a/src/features/place/components/place-list/index.ts
+++ b/src/features/place/components/place-list/index.ts
@@ -1,1 +1,0 @@
-export * from './PlaceList';

--- a/src/features/place/components/search-result-bar/SearchResultBar.tsx
+++ b/src/features/place/components/search-result-bar/SearchResultBar.tsx
@@ -26,7 +26,7 @@ export function SearchResultBar() {
   };
 
   return (
-    <div className="sticky top-0 z-50 w-full border-b border-gray-200 bg-white px-4 py-3 shadow-sm">
+    <div className="sticky top-0 z-5 w-full border-b border-gray-200 bg-white px-4 py-3 shadow-sm">
       <div className="mx-auto flex max-w-screen-lg items-center gap-2">
         <button
           onClick={() => router.push('/')}


### PR DESCRIPTION
## 📝 PR 개요
PlaceList 컴포넌트의 UI/UX를 개선하고, 레이아웃 구조를 개선했습니다.

## 🔍 변경사항
- PlaceList 컴포넌트를 PlaceListBottomSheet로 이름 변경하여 직관성 향상
- 검색 페이지 컴포넌트들의 z-index 값 적절하게 조정
- PlaceBottomSheet 상단 막대바 삭제로 UI 개선
- PlaceList 높이 조절로 사용성 개선
- 불필요한 기능 제거로 코드 최적화
- SearchResultBar 컴포넌트를 레이아웃에 더 적합한 위치로 이동

## 🧪 테스트
- [x] 바텀시트 드래그 동작 테스트
- [x] 검색바 클릭 및 포커스 테스트
- [x] z-index 레이어 순서 확인
- [x] 반응형 레이아웃 테스트
