### PR TITLE
Feat/#86 지도 영역 벗어나면 토스트 메시지 보여주도록 설정

### DIFF
--- a/src/features/place/components/map/Map.tsx
+++ b/src/features/place/components/map/Map.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '../../constants';
+import { usePlaceToast } from '../../hooks';
 import { useBottomSheetStore } from '../../stores';
 import { Place } from '../../types';
 import {
@@ -19,6 +20,7 @@ export interface MapProps {
 }
 
 export function Map({ places }: MapProps) {
+  const { showToast } = usePlaceToast();
   const mapRef = useRef<kakao.maps.Map | null>(null);
   const [isMapLoaded, setIsMapLoaded] = useState(false);
 
@@ -36,6 +38,10 @@ export function Map({ places }: MapProps) {
     resetSelectedMarker();
   }, [setOpened]);
 
+  const handleOutOfBounds = useCallback(() => {
+    showToast('지도 영역을 벗어났습니다.');
+  }, [showToast]);
+
   useEffect(() => {
     loadKakaoMapScript(() => {
       if (window.kakao && window.kakao.maps) {
@@ -46,6 +52,7 @@ export function Map({ places }: MapProps) {
               mapContainer,
               DEFAULT_LATITUDE,
               DEFAULT_LONGITUDE,
+              handleOutOfBounds,
             );
             mapRef.current = initializedMap;
             setIsMapLoaded(true);

--- a/src/features/place/utils/map.ts
+++ b/src/features/place/utils/map.ts
@@ -11,11 +11,7 @@ export function initializeMap(
   mapContainer: HTMLElement,
   lat: number = DEFAULT_LATITUDE,
   lng: number = DEFAULT_LONGITUDE,
-  onOutOfBounds?: (
-    map: kakao.maps.Map,
-    latLng: kakao.maps.LatLng,
-    bounds: kakao.maps.LatLngBounds,
-  ) => void,
+  onOutOfBounds?: () => void,
 ) {
   const latLng = new window.kakao.maps.LatLng(lat, lng);
   const mapOption = {
@@ -36,7 +32,7 @@ export function initializeMap(
     const center = map.getCenter();
     if (!isInBounds(bounds, center)) {
       map.setCenter(latLng);
-      if (onOutOfBounds) onOutOfBounds(map, latLng, bounds);
+      if (onOutOfBounds) onOutOfBounds();
     }
   };
   window.kakao.maps.event.addListener(map, 'dragend', keepCenterIfOutOfBounds);


### PR DESCRIPTION
## 📝 PR 개요

지도 영역을 벗어났을 때 사용자에게 토스트 메시지를 보여주어 UX를 개선합니다.

## 🔍 변경사항

- 토스트 메시지 구현
  - "지도 영역을 벗어났습니다." 메시지 표시
  - 사용자 친화적인 알림 제공

## 🔗 관련 이슈

Closes #86

## 📸 스크린샷

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/aba18985-3301-430f-b0ac-ab422677da41" />

## 🧪 테스트

- [ ] 지도 드래그로 영역 벗어남 시 토스트 메시지 표시 확인
- [ ] 지도 줌으로 영역 벗어남 시 토스트 메시지 표시 확인
- [ ] 영역 벗어남 시 자동으로 중심점 복원 확인
- [ ] 토스트 메시지 디자인 및 표시 시간 확인

## 🚨 주의사항

- 모바일 환경에서의 사용자 경험 확인 필요
