### PR TITLE
Feat/#84 유저폼 헬퍼텍스트 추가 및 input maxLength 추가

### DIFF
--- a/src/features/place/components/map/Map.tsx
+++ b/src/features/place/components/map/Map.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '../../constants';
+import { usePlaceToast } from '../../hooks';
 import { useBottomSheetStore } from '../../stores';
 import { Place } from '../../types';
 import {
@@ -19,6 +20,7 @@ export interface MapProps {
 }
 
 export function Map({ places }: MapProps) {
+  const { showToast } = usePlaceToast();
   const mapRef = useRef<kakao.maps.Map | null>(null);
   const [isMapLoaded, setIsMapLoaded] = useState(false);
 
@@ -36,6 +38,10 @@ export function Map({ places }: MapProps) {
     resetSelectedMarker();
   }, [setOpened]);
 
+  const handleOutOfBounds = useCallback(() => {
+    showToast('지도 영역을 벗어났습니다.');
+  }, [showToast]);
+
   useEffect(() => {
     loadKakaoMapScript(() => {
       if (window.kakao && window.kakao.maps) {
@@ -46,6 +52,7 @@ export function Map({ places }: MapProps) {
               mapContainer,
               DEFAULT_LATITUDE,
               DEFAULT_LONGITUDE,
+              handleOutOfBounds,
             );
             mapRef.current = initializedMap;
             setIsMapLoaded(true);

--- a/src/features/place/utils/map.ts
+++ b/src/features/place/utils/map.ts
@@ -11,11 +11,7 @@ export function initializeMap(
   mapContainer: HTMLElement,
   lat: number = DEFAULT_LATITUDE,
   lng: number = DEFAULT_LONGITUDE,
-  onOutOfBounds?: (
-    map: kakao.maps.Map,
-    latLng: kakao.maps.LatLng,
-    bounds: kakao.maps.LatLngBounds,
-  ) => void,
+  onOutOfBounds?: () => void,
 ) {
   const latLng = new window.kakao.maps.LatLng(lat, lng);
   const mapOption = {
@@ -36,7 +32,7 @@ export function initializeMap(
     const center = map.getCenter();
     if (!isInBounds(bounds, center)) {
       map.setCenter(latLng);
-      if (onOutOfBounds) onOutOfBounds(map, latLng, bounds);
+      if (onOutOfBounds) onOutOfBounds();
     }
   };
   window.kakao.maps.event.addListener(map, 'dragend', keepCenterIfOutOfBounds);

--- a/src/features/user/components/profile-form/ProfileForm.tsx
+++ b/src/features/user/components/profile-form/ProfileForm.tsx
@@ -30,10 +30,10 @@ const profileSchema = z.object({
   username: z
     .string()
     .min(2, '2자 이상 입력해주세요')
-    .max(10)
+    .max(10, '10자 이하로 입력해주세요')
     .regex(/^[가-힣a-zA-Z0-9\s]+$/, '특수문자는 사용할 수 없습니다')
     .trim(),
-  introduction: z.string().max(70).optional(),
+  introduction: z.string().max(70, '70자 이하로 입력해주세요').optional(),
 });
 
 type ProfileFormValues = z.infer<typeof profileSchema>;
@@ -219,6 +219,7 @@ export function ProfileForm({
               <FormLabel className="heading-2">닉네임</FormLabel>
               <Input
                 placeholder="닉네임을 입력하세요"
+                maxLength={10}
                 {...field}
                 className="input-text"
                 disabled={isSubmittingForm}
@@ -235,6 +236,7 @@ export function ProfileForm({
               <FormLabel className="heading-2">소개글</FormLabel>
               <Textarea
                 placeholder="간단한 소개를 입력하세요"
+                maxLength={70}
                 {...field}
                 className="input-text"
                 disabled={isSubmittingForm}


### PR DESCRIPTION
## 📝 PR 개요

프로필 폼의 사용자 경험을 개선하기 위해 입력 필드에 실시간 글자 수 표시 기능을 추가했습니다.

## 🔍 변경사항

- 닉네임 입력 필드 개선
  - 실시간 글자 수 표시 (0/10)
  - 입력 필드 우측에 현재 입력된 글자 수 표시
  - 최대 글자 수(10자) 제한 유지

- 소개글 입력 필드 개선
  - 실시간 글자 수 표시 (0/70)
  - 입력 필드 우측 하단에 현재 입력된 글자 수 표시
  - 최대 글자 수(70자) 제한 유지

## 🔗 관련 이슈

Closes #84 

## 📸 스크린샷

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/79faea0b-5808-486c-a8f3-4a74f0d24f76" />

## 🧪 테스트

- [ ] 닉네임 입력 시 실시간 글자 수 표시 확인
- [ ] 소개글 입력 시 실시간 글자 수 표시 확인
- [ ] 최대 글자 수 제한 정상 작동 확인
- [ ] 모바일 환경에서의 레이아웃 확인
- [ ] 입력 필드 포커스 시 글자 수 표시 가시성 확인

## 🚨 주의사항

- 글자 수 표시가 입력 필드의 내용을 가리지 않도록 주의
- 모바일 환경에서의 사용자 경험 확인 필요
- 입력 필드 포커스 시 글자 수 표시의 가시성 확인 필요