### PR TITLE
Refactor/#121 컴포넌트 props 타입 이름 변경

### DIFF
--- a/src/features/place/components/place-list-bottom-sheet/PlaceListBottomSheet.tsx
+++ b/src/features/place/components/place-list-bottom-sheet/PlaceListBottomSheet.tsx
@@ -12,11 +12,11 @@ import { useBottomSheetStore } from '../../stores';
 import { Place } from '../../types';
 import { PlaceItem } from '../place-item';
 
-export interface PlaceListProps {
+export interface PlaceListBottomSheetProps {
   places: Place[];
 }
 
-export function PlaceListBottomSheet({ places }: PlaceListProps) {
+export function PlaceListBottomSheet({ places }: PlaceListBottomSheetProps) {
   const { opened, prevSnap, scrollY, setPrevSnap, setScrollY } =
     useBottomSheetStore();
 

--- a/src/features/place/components/place-pin-bottom-sheet/PlacePinBottomSheet.tsx
+++ b/src/features/place/components/place-pin-bottom-sheet/PlacePinBottomSheet.tsx
@@ -6,7 +6,7 @@ import { useBottomSheetStore } from '../../stores';
 import { Place } from '../../types';
 import { PlaceItem } from '../place-item';
 
-interface PlaceBottomSheetProps {
+interface PlacePinBottomSheetProps {
   onOpenChange: (open: boolean) => void;
   place: Place | null;
 }
@@ -14,7 +14,7 @@ interface PlaceBottomSheetProps {
 export function PlacePinBottomSheet({
   onOpenChange,
   place,
-}: PlaceBottomSheetProps) {
+}: PlacePinBottomSheetProps) {
   const opened = useBottomSheetStore((state) => state.opened);
   const isOpen = opened === 'pin';
 


### PR DESCRIPTION
## 📝 PR 개요

컴포넌트명 변경 후 누락되었던 컴포넌트의 Props 타입 이름을 일관성 있게 수정합니다.

## 🔍 변경사항

- 특정 컴포넌트의 Props 인터페이스/타입 이름 변경
- 컴포넌트 파일 내부 및 해당 타입을 사용하는 다른 파일에서 이름 수정

## 주요 변경사항

- 컴포넌트명과 Props 타입명의 일관성 확보
- 코드 가독성 및 유지보수성 향상

## 🔗 관련 이슈

- Closes #121 


## 🧪 테스트 (Optional)

- [ ] 해당 컴포넌트가 Props를 정상적으로 받아오고 동작하는지 확인
- [ ] 타입스크립트 에러가 발생하지 않는지 확인

## 🚨 주의사항 (Optional)

- 단순 타입명 변경으로, 기능상의 변화는 없습니다.
- 해당 타입을 직접 사용하고 있는 다른 부분이 있다면 함께 수정되었는지 확인이 필요합니다.