### PR TITLE
Feat/#89 장소 리스트 정렬 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.4",
+    "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   '@radix-ui/react-label':
     specifier: ^2.1.4
     version: 2.1.4(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+  '@radix-ui/react-select':
+    specifier: ^2.2.5
+    version: 2.2.5(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
   '@radix-ui/react-slot':
     specifier: ^1.2.0
     version: 1.2.0(@types/react@19.1.2)(react@19.1.0)
@@ -227,6 +230,34 @@ packages:
       '@eslint/core': 0.13.0
       levn: 0.4.1
     dev: true
+
+  /@floating-ui/core@1.7.1:
+    resolution: {integrity: sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==}
+    dependencies:
+      '@floating-ui/utils': 0.2.9
+    dev: false
+
+  /@floating-ui/dom@1.7.1:
+    resolution: {integrity: sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==}
+    dependencies:
+      '@floating-ui/core': 1.7.1
+      '@floating-ui/utils': 0.2.9
+    dev: false
+
+  /@floating-ui/react-dom@2.1.3(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      '@floating-ui/dom': 1.7.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@floating-ui/utils@0.2.9:
+    resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+    dev: false
 
   /@floating-ui/core@1.7.1:
     resolution: {integrity: sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==}
@@ -578,6 +609,10 @@ packages:
       fastq: 1.19.1
     dev: true
 
+  /@radix-ui/number@1.1.1:
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+    dev: false
+
   /@radix-ui/primitive@1.1.2:
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
     dev: false
@@ -627,6 +662,26 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@radix-ui/react-checkbox@1.3.1(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-xTaLKAO+XXMPK/BpVTSaAAhlefmvMSACjIhK9mGsImvX2ljcTDm8VGR1CuS1uYcNdR5J+oiOhoJZc5un6bh3VQ==}
     peerDependencies:
@@ -648,6 +703,29 @@ packages:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
       '@types/react': 19.1.2
       '@types/react-dom': 19.1.2(@types/react@19.1.2)
       react: 19.1.0
@@ -806,6 +884,43 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-direction@1.1.1(@types/react@19.1.2)(react@19.1.0):
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 19.1.2
+      react: 19.1.0
+    dev: false
+
+  /@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@radix-ui/react-dismissable-layer@1.1.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-j5+WBUdhccJsmH5/H0K6RncjDtoALSEr6jbkaZu+bjw6hOPOhHycr6vEUujl+HBK8kjUfWcoCJXxP6e4lUlMZw==}
     peerDependencies:
@@ -913,6 +1028,28 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@radix-ui/react-id@1.1.1(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -941,6 +1078,35 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/react-primitive': 2.1.0(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@radix-ui/react-popper@1.2.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@floating-ui/react-dom': 2.1.3(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/rect': 1.1.1
       '@types/react': 19.1.2
       '@types/react-dom': 19.1.2(@types/react@19.1.2)
       react: 19.1.0
@@ -1055,6 +1221,27 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@radix-ui/react-presence@1.1.4(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==}
     peerDependencies:
@@ -1136,6 +1323,66 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-select@2.2.5(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      aria-hidden: 1.2.4
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.6.3(@types/react@19.1.2)(react@19.1.0)
+    dev: false
+
+  /@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@radix-ui/react-roving-focus@1.1.10(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
     resolution: {integrity: sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==}
     peerDependencies:
@@ -1180,6 +1427,20 @@ packages:
 
   /@radix-ui/react-slot@1.2.2(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      react: 19.1.0
+    dev: false
+
+  /@radix-ui/react-slot@1.2.3(@types/react@19.1.2)(react@19.1.0):
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1355,6 +1616,20 @@ packages:
       react: 19.1.0
     dev: false
 
+  /@radix-ui/react-use-rect@1.1.1(@types/react@19.1.2)(react@19.1.0):
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      '@types/react': 19.1.2
+      react: 19.1.0
+    dev: false
+
   /@radix-ui/react-use-size@1.1.1(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
@@ -1367,6 +1642,30 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.2)(react@19.1.0)
       '@types/react': 19.1.2
       react: 19.1.0
+    dev: false
+
+  /@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@radix-ui/rect@1.1.1:
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
     dev: false
 
   /@radix-ui/rect@1.1.1:

--- a/src/features/place/components/category-list/Category.tsx
+++ b/src/features/place/components/category-list/Category.tsx
@@ -13,7 +13,7 @@ export function Category({ category }: { category: string }) {
     router.push(
       `/search?category=${category}&lat=${DEFAULT_LATITUDE}&lng=${DEFAULT_LONGITUDE}`,
     );
-    resetForNewSearch();
+    resetForNewSearch('category');
   };
 
   return (

--- a/src/features/place/components/place-list-bottom-sheet/PlaceListBottomSheet.tsx
+++ b/src/features/place/components/place-list-bottom-sheet/PlaceListBottomSheet.tsx
@@ -81,7 +81,7 @@ export function PlaceListBottomSheet({ places }: PlaceListBottomSheetProps) {
             <div className="space-y-8">
               {sortedPlaces.map((place) => (
                 <div key={place.id} className="border-b border-zinc-200 pb-8">
-                  <PlaceItem key={place.id} place={place} isClickable />
+                  <PlaceItem place={place} isClickable />
                 </div>
               ))}
             </div>

--- a/src/features/place/components/place-list-bottom-sheet/PlaceListBottomSheet.tsx
+++ b/src/features/place/components/place-list-bottom-sheet/PlaceListBottomSheet.tsx
@@ -7,18 +7,28 @@ import {
   useBottomSheetSnapManagement,
   useGlobalFocusHandler,
   useScrollRestoration,
+  useSortedPlaceList,
 } from '../../hooks';
 import { useBottomSheetStore } from '../../stores';
 import { Place } from '../../types';
-import { PlaceList } from '../place-list';
+import { PlaceItem } from '../place-item';
+import { PlaceSortSelect } from '../place-sort-select';
 
 export interface PlaceListBottomSheetProps {
   places: Place[];
 }
 
 export function PlaceListBottomSheet({ places }: PlaceListBottomSheetProps) {
-  const { opened, prevSnap, scrollY, setPrevSnap, setScrollY } =
-    useBottomSheetStore();
+  const {
+    opened,
+    prevSnap,
+    scrollY,
+    sortType,
+    searchType,
+    setPrevSnap,
+    setScrollY,
+    setSortType,
+  } = useBottomSheetStore();
 
   const isOpen = opened === 'list';
 
@@ -33,6 +43,8 @@ export function PlaceListBottomSheet({ places }: PlaceListBottomSheetProps) {
     persistedScrollY: scrollY,
     setPersistedScrollY: setScrollY,
   });
+
+  const sortedPlaces = useSortedPlaceList({ places, sortType });
 
   useGlobalFocusHandler(isOpen);
 
@@ -50,6 +62,13 @@ export function PlaceListBottomSheet({ places }: PlaceListBottomSheetProps) {
           style={{ maxHeight: 'calc(100svh - 60px)' }}
         >
           <div className="mx-auto mt-4 h-1.5 w-12 rounded-full bg-zinc-300" />
+          <div className="flex w-full flex-row-reverse px-4">
+            <PlaceSortSelect
+              searchType={searchType}
+              sortType={sortType}
+              setSortType={setSortType}
+            />
+          </div>
           <Drawer.Title className="hidden">추천 장소 목록</Drawer.Title>
           <Drawer.Description className="hidden">
             당신이 원하는 장소를 추천해드립니다.
@@ -59,7 +78,13 @@ export function PlaceListBottomSheet({ places }: PlaceListBottomSheetProps) {
             onScroll={handleScroll}
             className="my-10 flex-1 overflow-y-auto px-4 pb-10"
           >
-            <PlaceList places={places} />
+            <div className="space-y-8">
+              {sortedPlaces.map((place) => (
+                <div key={place.id} className="border-b border-zinc-200 pb-8">
+                  <PlaceItem key={place.id} place={place} isClickable />
+                </div>
+              ))}
+            </div>
           </div>
         </Drawer.Content>
       </Drawer.Portal>

--- a/src/features/place/components/place-sort-select/PlaceSortSelect.tsx
+++ b/src/features/place/components/place-sort-select/PlaceSortSelect.tsx
@@ -1,0 +1,39 @@
+import { DataTransferBoth } from 'iconoir-react';
+
+import { SearchType, SortType } from '../../types';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/components';
+
+export interface PlaceSortSelectProps {
+  searchType: SearchType;
+  sortType: SortType;
+  setSortType: (sortType: SortType) => void;
+}
+
+export function PlaceSortSelect({
+  searchType,
+  sortType,
+  setSortType,
+}: PlaceSortSelectProps) {
+  return (
+    <Select value={sortType} onValueChange={setSortType}>
+      <SelectTrigger className="w-[120px] border-none shadow-none">
+        <DataTransferBoth className="h-4 w-4" />
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent className="w-[120px]">
+        <SelectItem value="distance">거리순</SelectItem>
+        {searchType === 'freeform' && (
+          <SelectItem value="similarity">유사도순</SelectItem>
+        )}
+        <SelectItem value="popularity">인기순</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/features/place/components/place-sort-select/PlaceSortSelect.tsx
+++ b/src/features/place/components/place-sort-select/PlaceSortSelect.tsx
@@ -1,5 +1,6 @@
 import { DataTransferBoth } from 'iconoir-react';
 
+import { SORT_OPTIONS } from '../../constants';
 import { SearchType, SortType } from '../../types';
 
 import {
@@ -28,11 +29,13 @@ export function PlaceSortSelect({
         <SelectValue />
       </SelectTrigger>
       <SelectContent className="w-[120px]">
-        <SelectItem value="distance">거리순</SelectItem>
-        {searchType === 'freeform' && (
-          <SelectItem value="similarity">유사도순</SelectItem>
-        )}
-        <SelectItem value="popularity">인기순</SelectItem>
+        {SORT_OPTIONS.filter(
+          (option) => !option.isVisible || option.isVisible(searchType),
+        ).map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
       </SelectContent>
     </Select>
   );

--- a/src/features/place/components/place-sort-select/index.ts
+++ b/src/features/place/components/place-sort-select/index.ts
@@ -1,0 +1,1 @@
+export * from './PlaceSortSelect';

--- a/src/features/place/components/search-bar/SearchBar.tsx
+++ b/src/features/place/components/search-bar/SearchBar.tsx
@@ -32,7 +32,7 @@ export function SearchBar({
       router.push(
         `/search?query=${encodeURIComponent(validatedQuery)}&lat=${DEFAULT_LATITUDE}&lng=${DEFAULT_LONGITUDE}`,
       );
-      resetForNewSearch();
+      resetForNewSearch('freeform');
     }
   };
 

--- a/src/features/place/components/search-result-bar/SearchResultBar.tsx
+++ b/src/features/place/components/search-result-bar/SearchResultBar.tsx
@@ -24,7 +24,7 @@ export function SearchResultBar() {
       router.push(
         `/search?query=${encodeURIComponent(validatedQuery)}&lat=${DEFAULT_LATITUDE}&lng=${DEFAULT_LONGITUDE}`,
       );
-      resetForNewSearch();
+      resetForNewSearch('freeform');
     }
   };
 

--- a/src/features/place/constants/bottomSheet.ts
+++ b/src/features/place/constants/bottomSheet.ts
@@ -1,6 +1,10 @@
+import { SearchType, SortType } from '../types';
+
 export const DEFAULT_BOTTOM_SHEET_INITIAL_SNAP = '255px';
 export const BOTTOM_SHEET_SNAP_POINTS = [
   DEFAULT_BOTTOM_SHEET_INITIAL_SNAP,
   '400px',
   1,
 ];
+export const DEFAULT_SORT_TYPE: SortType = 'distance';
+export const DEFAULT_SEARCH_TYPE: SearchType = 'freeform';

--- a/src/features/place/constants/index.ts
+++ b/src/features/place/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './map';
 export * from './bottomSheet';
+export * from './sortOptions';

--- a/src/features/place/constants/sortOptions.ts
+++ b/src/features/place/constants/sortOptions.ts
@@ -1,0 +1,23 @@
+import { SearchType, SortType } from '../types';
+
+export interface SortOption {
+  value: SortType;
+  label: string;
+  isVisible?: (searchType: SearchType) => boolean;
+}
+
+export const SORT_OPTIONS: SortOption[] = [
+  {
+    value: 'distance',
+    label: '거리순',
+  },
+  {
+    value: 'similarity',
+    label: '유사도순',
+    isVisible: (searchType) => searchType === 'freeform',
+  },
+  {
+    value: 'popularity',
+    label: '인기순',
+  },
+];

--- a/src/features/place/hooks/index.ts
+++ b/src/features/place/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useGlobalFocusHandler';
 export * from './usePlaceSearchParams';
 export * from './useSearchPlacesQuery';
 export * from './useBookmark';
+export * from './useSortedPlaceList';

--- a/src/features/place/hooks/useSortedPlaceList.ts
+++ b/src/features/place/hooks/useSortedPlaceList.ts
@@ -7,22 +7,21 @@ export interface UseSortedPlaceListProps {
   sortType: SortType;
 }
 
+const sorters: Record<SortType, (a: Place, b: Place) => number> = {
+  distance: (a, b) => a.distance - b.distance,
+  similarity: (a, b) => b.similarity_score - a.similarity_score,
+  popularity: (a, b) => b.moment_count - a.moment_count,
+};
+
 export function useSortedPlaceList({
   places,
   sortType,
 }: UseSortedPlaceListProps) {
   return useMemo(() => {
-    const copied = [...places];
+    const placesCopy = [...places];
+    const comparator = sorters[sortType] ?? (() => 0);
+    placesCopy.sort(comparator);
 
-    switch (sortType) {
-      case 'distance':
-        return copied.sort((a, b) => a.distance - b.distance);
-      case 'similarity':
-        return copied.sort((a, b) => b.similarity_score - a.similarity_score);
-      case 'popularity':
-        return copied.sort((a, b) => b.moment_count - a.moment_count);
-      default:
-        return copied;
-    }
+    return placesCopy;
   }, [places, sortType]);
 }

--- a/src/features/place/hooks/useSortedPlaceList.ts
+++ b/src/features/place/hooks/useSortedPlaceList.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+
+import { Place, SortType } from '../types';
+
+export interface UseSortedPlaceListProps {
+  places: Place[];
+  sortType: SortType;
+}
+
+export function useSortedPlaceList({
+  places,
+  sortType,
+}: UseSortedPlaceListProps) {
+  return useMemo(() => {
+    const copied = [...places];
+
+    switch (sortType) {
+      case 'distance':
+        return copied.sort((a, b) => a.distance - b.distance);
+      case 'similarity':
+        return copied.sort((a, b) => b.similarity_score - a.similarity_score);
+      case 'popularity':
+        return copied.sort((a, b) => b.moment_count - a.moment_count);
+      default:
+        return copied;
+    }
+  }, [places, sortType]);
+}

--- a/src/features/place/stores/bottomSheetStore.ts
+++ b/src/features/place/stores/bottomSheetStore.ts
@@ -16,26 +16,29 @@ export const useBottomSheetStore = create<BottomSheetState>((set) => ({
   setLastPlaceId: (lastPlaceId) => set({ lastPlaceId }),
   setSortType: (sortType) => set({ sortType }),
   resetForNewSearch: (searchType: SearchType) => {
-    if (searchType === 'category') {
-      set({
-        opened: 'list',
-        prevSnap: null,
-        scrollY: 0,
-        lastPlaceId: null,
-        sortType: 'distance',
-        searchType: 'category',
-      });
-    }
-
-    if (searchType === 'freeform') {
-      set({
-        opened: 'list',
-        prevSnap: null,
-        scrollY: 0,
-        lastPlaceId: null,
-        sortType: 'similarity',
-        searchType: 'freeform',
-      });
+    switch (searchType) {
+      case 'category':
+        set({
+          opened: 'list',
+          prevSnap: null,
+          scrollY: 0,
+          lastPlaceId: null,
+          sortType: 'distance',
+          searchType: 'category',
+        });
+        break;
+      case 'freeform':
+        set({
+          opened: 'list',
+          prevSnap: null,
+          scrollY: 0,
+          lastPlaceId: null,
+          sortType: 'similarity',
+          searchType: 'freeform',
+        });
+        break;
+      default:
+        throw new Error('Invalid search type');
     }
   },
 }));

--- a/src/features/place/stores/bottomSheetStore.ts
+++ b/src/features/place/stores/bottomSheetStore.ts
@@ -1,6 +1,10 @@
 import { create } from 'zustand';
 
-import { DEFAULT_BOTTOM_SHEET_INITIAL_SNAP } from '../constants';
+import {
+  DEFAULT_BOTTOM_SHEET_INITIAL_SNAP,
+  DEFAULT_SEARCH_TYPE,
+  DEFAULT_SORT_TYPE,
+} from '../constants';
 import { BottomSheetState, SearchType } from '../types';
 
 export const useBottomSheetStore = create<BottomSheetState>((set) => ({
@@ -8,8 +12,8 @@ export const useBottomSheetStore = create<BottomSheetState>((set) => ({
   prevSnap: DEFAULT_BOTTOM_SHEET_INITIAL_SNAP,
   scrollY: 0,
   lastPlaceId: null,
-  sortType: 'distance',
-  searchType: 'freeform',
+  sortType: DEFAULT_SORT_TYPE,
+  searchType: DEFAULT_SEARCH_TYPE,
   setOpened: (opened) => set({ opened }),
   setPrevSnap: (prevSnap) => set({ prevSnap }),
   setScrollY: (scrollY) => set({ scrollY }),

--- a/src/features/place/stores/bottomSheetStore.ts
+++ b/src/features/place/stores/bottomSheetStore.ts
@@ -1,17 +1,41 @@
 import { create } from 'zustand';
 
 import { DEFAULT_BOTTOM_SHEET_INITIAL_SNAP } from '../constants';
-import { BottomSheetState } from '../types';
+import { BottomSheetState, SearchType } from '../types';
 
 export const useBottomSheetStore = create<BottomSheetState>((set) => ({
   opened: 'list',
   prevSnap: DEFAULT_BOTTOM_SHEET_INITIAL_SNAP,
   scrollY: 0,
   lastPlaceId: null,
+  sortType: 'distance',
+  searchType: 'freeform',
   setOpened: (opened) => set({ opened }),
   setPrevSnap: (prevSnap) => set({ prevSnap }),
   setScrollY: (scrollY) => set({ scrollY }),
   setLastPlaceId: (lastPlaceId) => set({ lastPlaceId }),
-  resetForNewSearch: () =>
-    set({ opened: 'list', prevSnap: null, scrollY: 0, lastPlaceId: null }),
+  setSortType: (sortType) => set({ sortType }),
+  resetForNewSearch: (searchType: SearchType) => {
+    if (searchType === 'category') {
+      set({
+        opened: 'list',
+        prevSnap: null,
+        scrollY: 0,
+        lastPlaceId: null,
+        sortType: 'distance',
+        searchType: 'category',
+      });
+    }
+
+    if (searchType === 'freeform') {
+      set({
+        opened: 'list',
+        prevSnap: null,
+        scrollY: 0,
+        lastPlaceId: null,
+        sortType: 'similarity',
+        searchType: 'freeform',
+      });
+    }
+  },
 }));

--- a/src/features/place/types/bottomSheetStore.ts
+++ b/src/features/place/types/bottomSheetStore.ts
@@ -1,13 +1,20 @@
 export type BottomSheetType = 'list' | 'pin';
 
+export type SortType = 'distance' | 'similarity' | 'popularity';
+
+export type SearchType = 'category' | 'freeform';
+
 export interface BottomSheetState {
   opened: BottomSheetType;
   prevSnap: number | string | null;
   scrollY: number;
   lastPlaceId: number | null;
+  sortType: SortType;
+  searchType: SearchType;
   setOpened: (opened: BottomSheetType) => void;
   setPrevSnap: (prevSnap: number | string | null) => void;
   setScrollY: (scrollY: number) => void;
   setLastPlaceId: (lastPlaceId: number | null) => void;
-  resetForNewSearch: () => void;
+  setSortType: (sortType: SortType) => void;
+  resetForNewSearch: (searchType: SearchType) => void;
 }

--- a/src/features/place/types/place.ts
+++ b/src/features/place/types/place.ts
@@ -11,8 +11,9 @@ export interface Place {
   id: number;
   name: string;
   thumbnail: string;
-  distance: string;
-  moment_count: string;
+  distance: number;
+  moment_count: number;
+  similarity_score: number;
   keywords: string[];
   location: Location;
   is_bookmarked: boolean;

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -18,3 +18,4 @@ export * from './dropdown-menu';
 export * from './sheet';
 export * from './tab';
 export * from './loading-spinner';
+export * from './select';

--- a/src/shared/components/select/Select.tsx
+++ b/src/shared/components/select/Select.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+
+import { cn } from '@/shared/lib/utils';
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = 'popper',
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className,
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        'flex cursor-default items-center justify-center py-1',
+        className,
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        'flex cursor-default items-center justify-center py-1',
+        className,
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/shared/components/select/index.ts
+++ b/src/shared/components/select/index.ts
@@ -1,0 +1,1 @@
+export * from './Select';


### PR DESCRIPTION
## 📝 PR 개요

사용자가 장소 리스트를 다양한 기준으로 정렬하여 볼 수 있도록 정렬 기능을 추가하였습니다.  
이를 위해 커스텀 훅, UI 컴포넌트, 전역 상태 관리 로직이 구현되었습니다.

## 🔍 변경사항

- **정렬 기능 핵심 로직 구현:**
    - 장소 리스트 정렬 관련 로직을 `useSortedPlaceList`  커스텀 훅으로 분리
    - 검색 타입에 따라 정렬 관련 전역 상태 값 설정 로직 추가
- **UI 컴포넌트 추가:**
    - 정렬 옵션을 선택할 수 있는 `PlaceSortSelect` 컴포넌트 신규 추가
    - `shadcn/ui`의 `select` 컴포넌트를 기반으로 UI 구성
- **상태 관리 및 타입 정의:**
    - 정렬 기능에 필요한 전역 상태 변수 추가 (Zustand 활용)
    - 백엔드 장소 데이터 타입과 일치하도록 기존 타입 수정 및 정렬을 위한 `유사도` 등의 타입 추가

## 주요 변경사항

- `PlaceSortSelect` 컴포넌트를 통해 사용자가 정렬 기준(예: 거리순, 인기순, 유사도순 등)을 선택 가능
- 카테고리 검색은 '유사도' 선택이 존재하고 존재하지 않음
- 선택된 정렬 기준에 따라 장소 리스트가 실시간으로 재정렬되어 표시
- 정렬 상태는 전역으로 관리되어 다른 컴포넌트나 페이지 이동 시에도 유지될 수 있는 기반 마련
- 데이터 타입 업데이트로 백엔드 스키마 변경과 동기화, 새로운 정렬 기준(유사도) 추가

## 🔗 관련 이슈

Closes #89 

## 📸 스크린샷 (Optional)

<img width="148" alt="image" src="https://github.com/user-attachments/assets/f464f250-c9e9-424f-a0cd-3a1d70d48474" />

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/9d3983a4-f050-4903-bba5-95317c5f9939" />


## 🧪 테스트 (Optional)

- [ ] `PlaceSortSelect` 컴포넌트가 정상적으로 노출되고, 정렬 옵션 선택이 가능한지 확인
- [ ] 각 정렬 옵션(거리순, 인기순, 유사도순 등)을 선택했을 때 장소 리스트가 올바르게 정렬되는지 확인
    - [ ] 카테고리 검색 - 거리순, 인기순
    - [ ] 일반 검색 - 거리순, 인기순, 유사도순
- [ ] 정렬 상태가 전역적으로 잘 관리되고, 필요한 경우 유지되는지 확인
- [ ] 검색 타입 변경 시 관련 전역 변수 값이 올바르게 설정되는지 확인

## 🚨 주의사항 (Optional)

- 새로운 정렬 기준 추가 시, 커스텀 훅 및 전역 상태 로직, 타입 정의 부분을 함께 수정해야 합니다.
- `shadcn/ui` select 컴포넌트의 스타일 커스터마이징이 필요할 수 있습니다.
