### PR TITLE
Style/#127 내비바 아이콘 변경 및 문구 삭제, 헤더 문구 삭제

### DIFF
--- a/src/app/(main)/moments/page.tsx
+++ b/src/app/(main)/moments/page.tsx
@@ -3,7 +3,7 @@ import { Header } from '@/shared/components';
 export default function Moments() {
   return (
     <>
-      <Header title="다이어리" />
+      <Header />
       <div className="flex h-[calc(100svh-64px)] items-center justify-center text-center text-gray-500">
         곧 여러분을 찾아갈 새로운 기능을 준비 중이에요!
       </div>

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -39,7 +39,7 @@ export default function MyPage() {
 
   return (
     <>
-      <Header title="마이페이지" />
+      <Header />
       <div className="mt-12 flex flex-col items-center px-4">
         <Profile
           username={username}

--- a/src/shared/components/bottom-navigation/BottomNavigation.tsx
+++ b/src/shared/components/bottom-navigation/BottomNavigation.tsx
@@ -25,7 +25,7 @@ export function BottomNavigation() {
       <ul className="flex h-full items-center justify-between px-6">
         {navigationItems.map((item) => (
           <BottomNavigationItem
-            key={item.label}
+            key={item.href}
             item={item}
             isActive={activeItem === item.href}
             onClick={() => handleClick(item.href)}

--- a/src/shared/components/bottom-navigation/BottomNavigationItem.tsx
+++ b/src/shared/components/bottom-navigation/BottomNavigationItem.tsx
@@ -35,11 +35,6 @@ export function BottomNavigationItem({
             >
               {isActive ? item.solidIcon : item.icon}
             </div>
-            <span
-              className={`text-xs ${isActive ? 'font-medium' : 'text-gray-500'}`}
-            >
-              {item.label}
-            </span>
           </>
         )}
       </button>

--- a/src/shared/components/bottom-navigation/navigation-config.tsx
+++ b/src/shared/components/bottom-navigation/navigation-config.tsx
@@ -1,8 +1,13 @@
-import { Book, BookSolid, Home, HomeAlt, UserCircle } from 'iconoir-react';
+import {
+  Home,
+  HomeAlt,
+  MultiBubble,
+  MultiBubbleSolid,
+  UserCircle,
+} from 'iconoir-react';
 import React from 'react';
 
 export interface NavItem {
-  label: string;
   icon: React.ReactNode;
   solidIcon: React.ReactNode;
   href: string;
@@ -11,22 +16,19 @@ export interface NavItem {
 
 export const navigationItems: NavItem[] = [
   {
-    label: '다이어리',
-    icon: <Book className="h-6 w-6" />,
-    solidIcon: <BookSolid className="h-6 w-6" />,
+    icon: <MultiBubble className="h-8 w-8" />,
+    solidIcon: <MultiBubbleSolid className="h-8 w-8" />,
     href: '/moments',
   },
   {
-    label: '홈',
     icon: <Home className="h-12 w-12" />,
     solidIcon: <HomeAlt className="h-12 w-12" />,
     href: '/',
     isHome: true,
   },
   {
-    label: 'MY',
-    icon: <UserCircle className="h-7 w-7" />,
-    solidIcon: <UserCircle className="h-7 w-7" />,
+    icon: <UserCircle className="h-8 w-8" />,
+    solidIcon: <UserCircle className="h-8 w-8" />,
     href: '/mypage',
   },
 ];


### PR DESCRIPTION
## 📝 PR 개요

기록목록 페이지와 마이페이지의 헤더 및 네비게이션 바 UI를 일부 수정하였습니다.

## 🔍 변경사항

- **기록목록 페이지 네비바 아이콘 변경:**
    - 기록목록 페이지를 나타내는 네비게이션 바의 아이콘을 새로운 아이콘으로 교체하였습니다.
- **헤더 네비바 문구 삭제:**
    - 기록목록 페이지와 마이페이지의 헤더 네비게이션 바에서 기존에 표시되던 문구를 삭제하여 아이콘만으로 간결하게 표시되도록 변경하였습니다.

## 주요 변경사항

- 기록목록 페이지 아이콘 직관성 개선
- 헤더 네비게이션 바 UI 간소화로 더 깔끔한 화면 제공

## 🔗 관련 이슈

Closes #127 

## 📸 스크린샷 (Optional)

<img width="740" alt="image" src="https://github.com/user-attachments/assets/7e4deac3-f4e4-467e-aeb9-ea57dac5e476" />
<img width="511" alt="image" src="https://github.com/user-attachments/assets/cc28f606-8529-496e-a7a4-53f404be7b33" />



## 🧪 테스트 (Optional)

- [ ] 기록목록 페이지 네비바에 변경된 아이콘이 올바르게 표시되는지 확인
- [ ] 기록목록 페이지와 마이페이지 헤더 네비게이션 바에서 문구가 삭제되고 아이콘만 표시되는지 확인
- [ ] 다른 페이지의 네비게이션 바에 영향을 주지 않는지 확인

## 🚨 주의사항 (Optional)

- 아이콘 변경 및 문구 삭제는 시각적인 변화로, 기능상의 변화는 없습니다.
