### PR TITLE
Refactor/#129 유저 프로필 이미지 공통 컴포넌트로 분리 (UserAvatar)

### DIFF
--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -43,7 +43,7 @@ export default function MyPage() {
       <div className="mt-12 flex flex-col items-center px-4">
         <Profile
           username={username}
-          profile_image={profile_image ?? ''}
+          profileImage={profile_image ?? ''}
           introduction={introduction ?? ''}
         />
         <button

--- a/src/features/user/components/profile/Profile.tsx
+++ b/src/features/user/components/profile/Profile.tsx
@@ -1,34 +1,22 @@
 'use client';
 
-import { User } from 'iconoir-react';
+import { UserAvatar } from '@/shared/components';
 
 interface ProfileProps {
   username: string;
-  profile_image: string;
+  profileImage: string;
   introduction: string;
 }
 
 export function Profile({
   username,
-  profile_image,
+  profileImage,
   introduction,
 }: ProfileProps) {
   return (
     <div className="flex flex-col items-center px-4 py-6">
-      <div className="relative mb-4 aspect-square w-32 overflow-hidden rounded-full">
-        {profile_image ? (
-          <img
-            src={profile_image}
-            alt={username}
-            className="h-full w-full object-cover"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center bg-gray-200">
-            <User className="h-12 w-12 text-gray-400" />
-          </div>
-        )}
-      </div>
-      <h1 className="heading-2 mb-2">{username}</h1>
+      <UserAvatar imageUrl={profileImage} size="large" />
+      <h1 className="heading-2 mt-4 mb-2">{username}</h1>
       <p className="body-text mb-4 text-center whitespace-pre-line text-gray-600">
         {introduction}
       </p>

--- a/src/features/user/components/profile/index.ts
+++ b/src/features/user/components/profile/index.ts
@@ -1,1 +1,1 @@
-export { Profile } from './Profile';
+export * from './Profile';

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -12,3 +12,4 @@ export * from './checkbox';
 export * from './feedback-button';
 export * from './background-panel';
 export * from './full-screen-message';
+export * from './user-avatar';

--- a/src/shared/components/user-avatar/UserAvatar.tsx
+++ b/src/shared/components/user-avatar/UserAvatar.tsx
@@ -1,0 +1,41 @@
+import { User } from 'iconoir-react';
+import Image from 'next/image';
+
+export interface UserAvatarProps {
+  imageUrl?: string;
+  size?: 'small' | 'medium' | 'large';
+}
+
+export function UserAvatar({ imageUrl, size = 'medium' }: UserAvatarProps) {
+  const sizeMap = {
+    small: 12,
+    medium: 24,
+    large: 32,
+  };
+
+  const iconSizeMap = {
+    small: 8,
+    medium: 12,
+    large: 24,
+  };
+
+  return (
+    <div
+      className={`relative aspect-square w-${sizeMap[size]} w- overflow-hidden rounded-full`}
+    >
+      {imageUrl ? (
+        <Image
+          src={imageUrl}
+          alt="user avatar"
+          className="h-full w-full object-cover"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center bg-gray-200">
+          <User
+            className={`h-${iconSizeMap[size]} w-${iconSizeMap[size]} text-gray-400`}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/shared/components/user-avatar/index.ts
+++ b/src/shared/components/user-avatar/index.ts
@@ -1,0 +1,1 @@
+export * from './UserAvatar';


### PR DESCRIPTION

## 📝 PR 개요

여러 페이지에서 반복적으로 사용되는 유저 프로필 이미지 표시 로직을 공통 컴포넌트인 `UserAvatar`로 분리하였습니다.

## 🔍 변경사항

- **`UserAvatar` 컴포넌트 신규 생성:**
    - 유저 프로필 이미지를 표시하는 `UserAvatar` 컴포넌트를 구현하였습니다.
    - 이미지 URL을 props로 받아 이미지를 렌더링하며, 이미지가 없을 경우 기본 이미지를 표시하는 기능 등을 포함할 수 있습니다. (구체적인 기능은 구현에 따라 명시)
- **적용 예정 페이지:**
    - 마이페이지
    - 기록 상세 페이지
    - 다른 유저 프로필 페이지
    - 기록 목록 페이지

## 주요 변경사항

- 코드 중복 제거 및 재사용성 향상
- 유저 프로필 이미지 표시 방식의 일관성 유지
- 향후 프로필 이미지 관련 기능 변경 시 `UserAvatar` 컴포넌트만 수정하면 되어 유지보수 용이성 증대


## 🔗 관련 이슈

Closes #129

## 🧪 테스트 (Optional)

- [ ] `UserAvatar` 컴포넌트가 다양한 크기 및 상황에서 정상적으로 프로필 이미지를 표시하는지 확인
- [ ] 프로필 이미지가 없는 경우 기본 이미지가 올바르게 표시되는지 확인 (구현된 경우)
- [ ] (적용 후) 각 예정 페이지에서 `UserAvatar` 컴포넌트가 기존 프로필 이미지를 잘 대체하는지 확인

## 🚨 주의사항 (Optional)

- 현재 PR은 `UserAvatar` 컴포넌트의 생성 및 분리에 중점을 두며, 각 페이지 실제 적용은 후속 PR에서 진행 예정입니다. 