### PR TITLE
Refactor/#134 ProfileForm 로직, 컴포넌트 분리

### DIFF
--- a/src/features/user/components/profile-form/ProfileForm.tsx
+++ b/src/features/user/components/profile-form/ProfileForm.tsx
@@ -6,6 +6,8 @@ import { useForm } from 'react-hook-form';
 
 import { ProfileFormValues, profileSchema } from '../../schemas';
 
+import { ProfileImageInput } from './ProfileImageInput';
+
 import {
   Button,
   Form,
@@ -80,42 +82,18 @@ export function ProfileForm({
         onSubmit={form.handleSubmit(handleFormSubmit)}
         className="mx-auto flex w-full max-w-sm flex-col items-center space-y-8 py-6"
       >
-        <div className="relative">
-          <div
-            onClick={() => !isSubmittingForm && triggerInput()}
-            className={`h-32 w-32 overflow-hidden rounded-full border-2 bg-gray-200 ${
-              isSubmittingForm
-                ? 'cursor-not-allowed opacity-70'
-                : 'cursor-pointer'
-            } ${form.formState.errors.profile_image ? 'border-destructive' : 'border-gray-300'}`}
-          >
-            {preview ? (
-              <img
-                src={preview as string}
-                alt="프로필 이미지"
-                className="h-full w-full object-cover"
-              />
-            ) : (
-              <div className="flex h-full w-full items-center justify-center text-gray-500">
-                {isSubmittingForm && isUploading ? '업로드중...' : '사진 선택'}
-              </div>
-            )}
-          </div>
-          <input
-            ref={inputRef}
-            type="file"
-            accept={acceptedTypes.join(',')}
-            className="hidden"
-            onChange={handleImageChange}
-            disabled={isSubmittingForm}
-          />
-        </div>
-        {form.formState.errors.profile_image?.message && (
-          <p className="text-destructive text-sm font-medium">
-            {form.formState.errors.profile_image?.message as string}
-          </p>
-        )}
-
+        <ProfileImageInput
+          preview={typeof preview === 'string' ? preview : null}
+          isUploading={isUploading}
+          triggerInput={triggerInput}
+          inputRef={inputRef}
+          acceptedTypes={acceptedTypes}
+          handleImageChange={handleImageChange}
+          isSubmitting={isSubmittingForm}
+          errorMessage={form.formState.errors.profile_image?.message as string}
+          isError={!!form.formState.errors.profile_image}
+          altText="프로필 이미지"
+        />
         <FormField
           control={form.control}
           name="username"

--- a/src/features/user/components/profile-form/ProfileForm.tsx
+++ b/src/features/user/components/profile-form/ProfileForm.tsx
@@ -3,7 +3,8 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRef, useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { z } from 'zod';
+
+import { ProfileFormValues, profileSchema } from '../../schemas';
 
 import {
   Button,
@@ -24,19 +25,6 @@ const ACCEPTED_IMAGE_TYPES = [
   'image/png',
   'image/webp',
 ];
-
-const profileSchema = z.object({
-  profile_image: z.string().optional(),
-  username: z
-    .string()
-    .min(2, '2자 이상 입력해주세요')
-    .max(10, '10자 이하로 입력해주세요')
-    .regex(/^[가-힣a-zA-Z0-9\s]+$/, '특수문자는 사용할 수 없습니다')
-    .trim(),
-  introduction: z.string().max(70, '70자 이하로 입력해주세요').optional(),
-});
-
-type ProfileFormValues = z.infer<typeof profileSchema>;
 
 export interface ProfileFormProps {
   onSubmit: (data: ProfileFormValues) => Promise<void>;

--- a/src/features/user/components/profile-form/ProfileForm.tsx
+++ b/src/features/user/components/profile-form/ProfileForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useRef, useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { ProfileFormValues, profileSchema } from '../../schemas';
@@ -16,15 +16,7 @@ import {
   Input,
   Textarea,
 } from '@/shared/components';
-import { useImageUpload } from '@/shared/hooks';
-
-const MAX_FILE_SIZE = 5 * 1024 * 1024;
-const ACCEPTED_IMAGE_TYPES = [
-  'image/jpeg',
-  'image/jpg',
-  'image/png',
-  'image/webp',
-];
+import { useImageInput } from '@/shared/hooks';
 
 export interface ProfileFormProps {
   onSubmit: (data: ProfileFormValues) => Promise<void>;
@@ -37,18 +29,7 @@ export function ProfileForm({
   defaultValues,
   buttonText = '저장',
 }: ProfileFormProps) {
-  const [preview, setPreview] = useState<string | null>(
-    defaultValues?.profile_image || null,
-  );
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isSubmittingForm, setIsSubmittingForm] = useState(false);
-
-  const inputRef = useRef<HTMLInputElement>(null);
-  const {
-    uploadImage,
-    isLoading: isUploadingImage,
-    error: imageUploadError,
-  } = useImageUpload();
 
   const form = useForm<ProfileFormValues>({
     resolver: zodResolver(profileSchema),
@@ -59,101 +40,39 @@ export function ProfileForm({
     },
   });
 
-  useEffect(() => {
-    if (defaultValues?.profile_image) {
-      setPreview(defaultValues.profile_image);
-      setSelectedFile(null);
-      form.setValue('profile_image', defaultValues.profile_image);
-    }
-  }, [defaultValues?.profile_image, form]);
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    form.clearErrors('profile_image');
-    setImageUploadError(null);
-
-    if (file) {
-      if (file.size > MAX_FILE_SIZE) {
-        form.setError('profile_image', {
-          type: 'manual',
-          message: `프로필 사진은 ${MAX_FILE_SIZE / 1024 / 1024}MB 이하만 가능합니다.`,
-        });
-        setSelectedFile(null);
-        setPreview(defaultValues?.profile_image || null);
-        return;
-      }
-      if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
-        form.setError('profile_image', {
-          type: 'manual',
-          message:
-            '프로필 사진은 .jpg, .jpeg, .png, .webp 확장자만 가능합니다.',
-        });
-        setSelectedFile(null);
-        setPreview(defaultValues?.profile_image || null);
-        return;
-      }
-
-      setSelectedFile(file);
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setPreview(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-    } else {
-      setSelectedFile(null);
-      setPreview(defaultValues?.profile_image || null);
-    }
-  };
-
-  const setImageUploadError = (error: Error | null) => {
-    if (error) {
-      form.setError('profile_image', {
-        type: 'manual',
-        message: error.message || '이미지 업로드 실패',
-      });
-    } else {
-      form.clearErrors('profile_image');
-    }
-  };
+  const {
+    preview,
+    isUploading,
+    inputRef,
+    acceptedTypes,
+    handleImageChange,
+    triggerInput,
+    upload,
+  } = useImageInput({
+    form,
+    fieldName: 'profile_image',
+    defaultImage: defaultValues?.profile_image,
+    uploadType: 'profile',
+  });
 
   const handleFormSubmit = async (data: ProfileFormValues) => {
     setIsSubmittingForm(true);
-    setImageUploadError(null);
 
-    let finalProfileImageUrl = data.profile_image;
+    const uploadedImageUrl = await upload();
 
-    if (selectedFile) {
-      const uploadedUrl = await uploadImage(selectedFile, 'profile');
-      if (uploadedUrl) {
-        finalProfileImageUrl = uploadedUrl;
-      } else {
-        if (imageUploadError) {
-          form.setError('profile_image', {
-            type: 'manual',
-            message:
-              imageUploadError.message ||
-              '이미지 업로드 중 문제가 발생했습니다.',
-          });
-        }
-        setIsSubmittingForm(false);
-        return;
+    if (uploadedImageUrl !== null) {
+      try {
+        await onSubmit({
+          ...data,
+          profile_image: uploadedImageUrl as string,
+        });
+      } catch (error) {
+        console.error('Form submission error:', error);
       }
     }
 
-    try {
-      await onSubmit({ ...data, profile_image: finalProfileImageUrl });
-    } catch (error) {
-      console.error('Form submission error:', error);
-    } finally {
-      setIsSubmittingForm(false);
-    }
+    setIsSubmittingForm(false);
   };
-
-  useEffect(() => {
-    if (imageUploadError && !selectedFile) {
-      setImageUploadError(imageUploadError);
-    }
-  }, [imageUploadError, form, selectedFile]);
 
   return (
     <Form {...form}>
@@ -163,7 +82,7 @@ export function ProfileForm({
       >
         <div className="relative">
           <div
-            onClick={() => !isSubmittingForm && inputRef.current?.click()}
+            onClick={() => !isSubmittingForm && triggerInput()}
             className={`h-32 w-32 overflow-hidden rounded-full border-2 bg-gray-200 ${
               isSubmittingForm
                 ? 'cursor-not-allowed opacity-70'
@@ -172,22 +91,20 @@ export function ProfileForm({
           >
             {preview ? (
               <img
-                src={preview}
+                src={preview as string}
                 alt="프로필 이미지"
                 className="h-full w-full object-cover"
               />
             ) : (
               <div className="flex h-full w-full items-center justify-center text-gray-500">
-                {isSubmittingForm && isUploadingImage
-                  ? '업로드중...'
-                  : '사진 선택'}
+                {isSubmittingForm && isUploading ? '업로드중...' : '사진 선택'}
               </div>
             )}
           </div>
           <input
             ref={inputRef}
             type="file"
-            accept={ACCEPTED_IMAGE_TYPES.join(',')}
+            accept={acceptedTypes.join(',')}
             className="hidden"
             onChange={handleImageChange}
             disabled={isSubmittingForm}
@@ -195,7 +112,7 @@ export function ProfileForm({
         </div>
         {form.formState.errors.profile_image?.message && (
           <p className="text-destructive text-sm font-medium">
-            {form.formState.errors.profile_image?.message}
+            {form.formState.errors.profile_image?.message as string}
           </p>
         )}
 
@@ -239,7 +156,7 @@ export function ProfileForm({
           disabled={isSubmittingForm}
         >
           {isSubmittingForm
-            ? isUploadingImage
+            ? isUploading
               ? '이미지 업로드 중'
               : '저장 중'
             : buttonText}

--- a/src/features/user/components/profile-form/ProfileImageInput.tsx
+++ b/src/features/user/components/profile-form/ProfileImageInput.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React from 'react';
+
+interface ProfileImageInputProps {
+  preview: string | null;
+  isUploading: boolean;
+  triggerInput: () => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  acceptedTypes: string[];
+  handleImageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  multiple?: boolean;
+  isSubmitting: boolean;
+  errorMessage?: string;
+  isError: boolean;
+  shape?: 'circle' | 'square';
+  altText?: string;
+  placeholderText?: string;
+  className?: string;
+  previewClassName?: string;
+}
+
+export function ProfileImageInput({
+  preview,
+  isUploading,
+  triggerInput,
+  inputRef,
+  acceptedTypes,
+  handleImageChange,
+  multiple = false,
+  isSubmitting,
+  errorMessage,
+  isError,
+  shape = 'circle',
+  altText = '이미지 프리뷰',
+  placeholderText = '사진 선택',
+  className,
+  previewClassName = 'h-32 w-32',
+}: ProfileImageInputProps) {
+  const renderSinglePreview = (src: string) => (
+    <img src={src} alt={altText} className="h-full w-full object-cover" />
+  );
+
+  const renderPlaceholder = () => (
+    <div className="flex h-full w-full items-center justify-center text-center text-gray-500">
+      {isUploading ? '업로드중...' : placeholderText}
+    </div>
+  );
+
+  const renderPreview = () => {
+    if (typeof preview === 'string') {
+      return renderSinglePreview(preview);
+    }
+    return renderPlaceholder();
+  };
+
+  const shapeClass = shape === 'circle' ? 'rounded-full' : 'rounded-md';
+  const interactionClass = isSubmitting
+    ? 'cursor-not-allowed opacity-70'
+    : 'cursor-pointer';
+  const borderClass = isError ? 'border-destructive' : 'border-gray-300';
+
+  return (
+    <div className={`flex flex-col items-center space-y-2 ${className}`}>
+      <div
+        onClick={() => !isSubmitting && triggerInput()}
+        className={`relative overflow-hidden border-2 bg-gray-200 ${previewClassName} ${shapeClass} ${interactionClass} ${borderClass}`}
+      >
+        {renderPreview()}
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={acceptedTypes.join(',')}
+        multiple={multiple}
+        className="hidden"
+        onChange={handleImageChange}
+        disabled={isSubmitting}
+      />
+      {errorMessage && (
+        <p className="text-destructive text-sm font-medium">{errorMessage}</p>
+      )}
+    </div>
+  );
+}

--- a/src/features/user/schemas/index.ts
+++ b/src/features/user/schemas/index.ts
@@ -1,0 +1,1 @@
+export * from './profile';

--- a/src/features/user/schemas/profile.ts
+++ b/src/features/user/schemas/profile.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const profileSchema = z.object({
+  profile_image: z.string().optional(),
+  username: z
+    .string()
+    .min(2, '2자 이상 입력해주세요')
+    .max(10, '10자 이하로 입력해주세요')
+    .regex(/^[가-힣a-zA-Z0-9\s]+$/, '특수문자는 사용할 수 없습니다')
+    .trim(),
+  introduction: z.string().max(70, '70자 이하로 입력해주세요').optional(),
+});
+
+export type ProfileFormValues = z.infer<typeof profileSchema>;

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useImageUpload';
+export * from './useImageInput';

--- a/src/shared/hooks/useImageInput.ts
+++ b/src/shared/hooks/useImageInput.ts
@@ -1,0 +1,168 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import type { UseFormReturn, FieldValues, Path } from 'react-hook-form';
+
+import { useImageUpload, UploadType } from './useImageUpload';
+
+interface UseImageInputProps<T extends FieldValues> {
+  form: UseFormReturn<T>;
+  fieldName: Path<T>;
+  defaultImage?: string | string[] | null;
+  uploadType: UploadType;
+  maxSize?: number;
+  acceptedTypes?: string[];
+  multiple?: boolean;
+}
+
+const DEFAULT_MAX_SIZE = 5 * 1024 * 1024; // 5MB
+const DEFAULT_ACCEPTED_TYPES = [
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+];
+
+export function useImageInput<T extends FieldValues>({
+  form,
+  fieldName,
+  defaultImage = null,
+  uploadType,
+  maxSize = DEFAULT_MAX_SIZE,
+  acceptedTypes = DEFAULT_ACCEPTED_TYPES,
+  multiple = false,
+}: UseImageInputProps<T>) {
+  const [preview, setPreview] = useState<string | string[] | null>(
+    defaultImage,
+  );
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const {
+    uploadImage,
+    isLoading: isUploading,
+    error: uploadError,
+    setError: setUploadError,
+  } = useImageUpload();
+
+  useEffect(() => {
+    setPreview(defaultImage);
+  }, [defaultImage]);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files ? Array.from(e.target.files) : [];
+    form.clearErrors(fieldName);
+    setUploadError(null);
+
+    if (files.length === 0) {
+      setSelectedFiles([]);
+      setPreview(defaultImage);
+      return;
+    }
+
+    if (!multiple && files.length > 1) {
+      form.setError(fieldName, {
+        type: 'manual',
+        message: '하나의 이미지만 선택할 수 있습니다.',
+      });
+      return;
+    }
+
+    const validationError = files.some((file) => {
+      if (file.size > maxSize) {
+        form.setError(fieldName, {
+          type: 'manual',
+          message: `이미지는 ${maxSize / 1024 / 1024}MB 이하만 가능합니다.`,
+        });
+        return true;
+      }
+      if (!acceptedTypes.includes(file.type)) {
+        form.setError(fieldName, {
+          type: 'manual',
+          message: `이미지는 ${acceptedTypes.join(', ')} 형식만 가능합니다.`,
+        });
+        return true;
+      }
+      return false;
+    });
+
+    if (validationError) {
+      setSelectedFiles([]);
+      setPreview(defaultImage);
+      return;
+    }
+
+    setSelectedFiles(files);
+
+    const newPreviews = files.map((file) => URL.createObjectURL(file));
+    setPreview(multiple ? newPreviews : newPreviews[0]);
+  };
+
+  const triggerInput = () => inputRef.current?.click();
+
+  const upload = useCallback(async () => {
+    if (selectedFiles.length === 0) {
+      return defaultImage;
+    }
+
+    try {
+      if (multiple) {
+        const uploadedUrls = await Promise.all(
+          selectedFiles.map((file) => uploadImage(file, uploadType)),
+        );
+        const successfulUrls = uploadedUrls.filter(
+          (url): url is string => url !== null,
+        );
+
+        if (successfulUrls.length !== selectedFiles.length) {
+          throw new Error('일부 이미지 업로드에 실패했습니다.');
+        }
+
+        form.setValue(fieldName, successfulUrls as T[Path<T>]);
+        return successfulUrls;
+      } else {
+        const uploadedUrl = await uploadImage(selectedFiles[0], uploadType);
+        if (uploadedUrl) {
+          form.setValue(fieldName, uploadedUrl as T[Path<T>]);
+          return uploadedUrl;
+        }
+        throw new Error('이미지 업로드에 실패했습니다.');
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : '이미지 업로드 중 문제가 발생했습니다.';
+      form.setError(fieldName, { type: 'manual', message });
+      return null;
+    }
+  }, [
+    selectedFiles,
+    uploadImage,
+    uploadType,
+    form,
+    fieldName,
+    defaultImage,
+    multiple,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      if (Array.isArray(preview)) {
+        preview.forEach((p) => URL.revokeObjectURL(p));
+      } else if (preview && preview.startsWith('blob:')) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, [preview]);
+
+  return {
+    preview,
+    isUploading,
+    uploadError,
+    inputRef,
+    acceptedTypes,
+    multiple,
+    handleImageChange,
+    triggerInput,
+    upload,
+  };
+}

--- a/src/shared/hooks/useImageUpload.ts
+++ b/src/shared/hooks/useImageUpload.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, Dispatch, SetStateAction } from 'react';
 
 import { getPresignedUrl, type PresignedUrlResponseData } from '@/shared/api';
 import { FetchApiError } from '@/shared/lib/fetchApi';
@@ -10,6 +10,7 @@ interface UseImageUploadResult {
   isLoading: boolean;
   error: Error | null;
   uploadedObjectUrl: string | null;
+  setError: Dispatch<SetStateAction<Error | null>>;
 }
 
 export function useImageUpload(): UseImageUploadResult {
@@ -68,5 +69,6 @@ export function useImageUpload(): UseImageUploadResult {
     isLoading,
     error,
     uploadedObjectUrl,
+    setError,
   };
 }


### PR DESCRIPTION
## 📝 PR 개요

프로필 이미지 업로드 관련 코드를 모듈화하여 재사용성과 유지보수성을 개선했습니다. Zod 스키마, 이미지 업로드 로직, UI 컴포넌트를 각각 분리하여 관심사를 명확히 분리했습니다.

## 🔍 변경사항

- **Zod 스키마 분리**
  - 프로필 폼의 유효성 검사 로직을 별도의 스키마 파일로 분리
  - 재사용 가능한 타입 정의 추가

- **이미지 업로드 로직 분리**
  - `useImageInput` 커스텀 훅 생성
  - 이미지 파일 처리, 미리보기, 업로드 상태 관리 로직 캡슐화
  - 단일/다중 이미지 업로드 지원

- **UI 컴포넌트 분리**
  - `ProfileImageInput` 컴포넌트 생성
  - 이미지 업로드 UI 로직을 재사용 가능한 컴포넌트로 분리
  - 프로필 폼의 복잡도 감소

## 🔗 관련 이슈

Closes #134 

## 🧪 테스트

- [ ] 프로필 이미지 업로드 정상 동작 확인
- [ ] 이미지 크기/형식 유효성 검사 확인
- [ ] 업로드 중 상태 표시 확인
- [ ] 에러 메시지 표시 확인

## 🚨 주의사항

- 이미지 업로드 시 메모리 누수 방지를 위해 `URL.createObjectURL` 생성된 URL을 컴포넌트 언마운트 시 정리하도록 구현했습니다.
- 다중 이미지 업로드 기능은 현재 프로필 이미지에서는 사용하지 않지만, 향후 확장성을 고려하여 `useImageInput` 훅에 구현되어 있습니다.