### PR TITLE
Feat/#98 기록 수정, 작성 페이지 UI 구성

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-checkbox": "^1.3.1",
     "@radix-ui/react-label": "^2.1.4",
     "@radix-ui/react-slot": "^1.2.0",
+    "@radix-ui/react-switch": "^1.2.5",
     "@tanstack/react-query": "^5.74.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   '@radix-ui/react-slot':
     specifier: ^1.2.0
     version: 1.2.0(@types/react@19.1.2)(react@19.1.0)
+  '@radix-ui/react-switch':
+    specifier: ^1.2.5
+    version: 1.2.5(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
   '@tanstack/react-query':
     specifier: ^5.74.7
     version: 5.74.7(react@19.1.0)
@@ -828,6 +831,26 @@ packages:
       react-dom: 19.1.0(react@19.1.0)
     dev: false
 
+  /@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
   /@radix-ui/react-slot@1.2.0(@types/react@19.1.2)(react@19.1.0):
     resolution: {integrity: sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==}
     peerDependencies:
@@ -854,6 +877,46 @@ packages:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
       '@types/react': 19.1.2
       react: 19.1.0
+    dev: false
+
+  /@radix-ui/react-slot@1.2.3(@types/react@19.1.2)(react@19.1.0):
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      react: 19.1.0
+    dev: false
+
+  /@radix-ui/react-switch@1.2.5(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-5ijLkak6ZMylXsaImpZ8u4Rlf5grRmoc0p0QeX9VJtlrM4f5m3nCTX8tWga/zOA8PZYIR/t0p2Mnvd7InrJ6yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     dev: false
 
   /@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.2)(react@19.1.0):

--- a/src/app/(main)/moments/new/page.tsx
+++ b/src/app/(main)/moments/new/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+  HeaderCheckButton,
+  HeaderVisibilityToggle,
+  MomentForm,
+} from '@/features/community';
+import { Header } from '@/shared/components';
+
+export default function NewMomentPage() {
+  const [isPublic, setIsPublic] = useState(false);
+  return (
+    <div className="overflow-y-auto pb-22">
+      <Header
+        showBackButton
+        rightElement={
+          <div className="flex flex-row items-center gap-4">
+            <HeaderVisibilityToggle
+              isPublic={isPublic}
+              onToggle={setIsPublic}
+            />
+            <HeaderCheckButton
+              onClick={() => console.log('clicked')}
+              disabled={false}
+            />
+          </div>
+        }
+      />
+      <MomentForm
+        onSubmit={async (data) => {
+          console.log(data);
+          await Promise.resolve();
+        }}
+        placeInfo={{
+          place_id: '1',
+          place_name: '테스트',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/app/(main)/moments/page.tsx
+++ b/src/app/(main)/moments/page.tsx
@@ -1,9 +1,14 @@
-import { dummyMomentListData, MomentList } from '@/features/community';
+import {
+  dummyMomentListData,
+  MomentList,
+  WriteMomentFab,
+} from '@/features/community';
 
 export default function Moments() {
   return (
-    <div className="overflow-scrolling-touch flex-1 overflow-y-auto pb-22">
+    <div className="overflow-y-auto pb-22">
       <MomentList moments={dummyMomentListData} />
+      <WriteMomentFab />
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,6 +80,12 @@ body {
   transition: max-width 0.3s ease-in-out;
 }
 
+.mobile-width {
+  width: 100%;
+  max-width: 430px;
+  min-width: 375px;
+}
+
 /* UI 컴포넌트 클래스 */
 .heading-1 {
   font-size: var(--font-size-heading-1);

--- a/src/features/community/components/header-check-button/HeaderCheckButton.tsx
+++ b/src/features/community/components/header-check-button/HeaderCheckButton.tsx
@@ -1,0 +1,21 @@
+import { CheckIcon } from 'lucide-react';
+
+interface HeaderCheckButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export function HeaderCheckButton({
+  onClick,
+  disabled = false,
+}: HeaderCheckButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`p-1 ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:opacity-80'}`}
+    >
+      <CheckIcon className="h-6 w-6" />
+    </button>
+  );
+}

--- a/src/features/community/components/header-check-button/index.ts
+++ b/src/features/community/components/header-check-button/index.ts
@@ -1,0 +1,1 @@
+export * from './HeaderCheckButton';

--- a/src/features/community/components/header-visibility-toggle/HeaderVisibilityToggle.tsx
+++ b/src/features/community/components/header-visibility-toggle/HeaderVisibilityToggle.tsx
@@ -1,0 +1,42 @@
+import { Switch } from '@/shared/components';
+import { cn } from '@/shared/lib/utils';
+
+interface HeaderVisibilityToggleProps {
+  isPublic: boolean;
+  onToggle: (checked: boolean) => void;
+}
+
+export function HeaderVisibilityToggle({
+  isPublic,
+  onToggle,
+}: HeaderVisibilityToggleProps) {
+  return (
+    <div className="relative inline-flex items-center">
+      <Switch
+        checked={isPublic}
+        onCheckedChange={onToggle}
+        className={cn(
+          'peer bg-muted relative h-8 w-20 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors',
+          'data-[state=checked]:bg-neutral-500',
+          '[&>span]:hidden',
+        )}
+      />
+
+      <span
+        className={cn(
+          'pointer-events-none absolute top-1 left-1 z-10 h-6 w-6 rounded-full bg-white transition-transform',
+          isPublic ? 'translate-x-12' : 'translate-x-0',
+        )}
+      />
+
+      <span
+        className={cn(
+          'pointer-events-none absolute top-1/2 left-1/2 z-20 w-16 -translate-x-1/2 -translate-y-1/2 text-[13px] font-medium text-white select-none',
+          isPublic ? 'ml-2.5' : 'ml-6.5',
+        )}
+      >
+        {isPublic ? '공개' : '비공개'}
+      </span>
+    </div>
+  );
+}

--- a/src/features/community/components/header-visibility-toggle/index.ts
+++ b/src/features/community/components/header-visibility-toggle/index.ts
@@ -1,0 +1,1 @@
+export * from './HeaderVisibilityToggle';

--- a/src/features/community/components/index.ts
+++ b/src/features/community/components/index.ts
@@ -1,1 +1,5 @@
 export * from './moment-list';
+export * from './header-check-button';
+export * from './header-visibility-toggle';
+export * from './moment-form';
+export * from './write-moment-fab';

--- a/src/features/community/components/moment-form/MomentForm.tsx
+++ b/src/features/community/components/moment-form/MomentForm.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { MomentFormValues, momentSchema } from '../../schemas';
+
+import { MomentImagesInput } from './MomentImagesInput';
+
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Textarea,
+} from '@/shared/components';
+
+export interface MomentFormProps {
+  onSubmit: (data: MomentFormValues) => Promise<void>;
+  defaultValues?: Partial<MomentFormValues>;
+  placeInfo?: {
+    place_id: string;
+    place_name: string;
+  };
+}
+
+export function MomentForm({
+  onSubmit,
+  defaultValues,
+  placeInfo,
+}: MomentFormProps) {
+  const [isSubmittingForm, setIsSubmittingForm] = useState(false);
+
+  const form = useForm<MomentFormValues>({
+    resolver: zodResolver(momentSchema),
+    defaultValues: {
+      title: defaultValues?.title || '',
+      content: defaultValues?.content || '',
+      place_id: defaultValues?.place_id || '',
+      place_name: defaultValues?.place_name || '',
+      images: defaultValues?.images || [],
+      is_public: defaultValues?.is_public || false,
+    },
+  });
+
+  const handleFormSubmit = async (data: MomentFormValues) => {
+    setIsSubmittingForm(true);
+
+    try {
+      await onSubmit({ ...data });
+    } catch (error) {
+      console.error('Form submission error:', error);
+    } finally {
+      setIsSubmittingForm(false);
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleFormSubmit)}
+        className="mx-auto flex w-full max-w-sm flex-col items-center space-y-8 py-6"
+      >
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem className="w-full">
+              <FormLabel className="heading-2">
+                제목
+                <span className="text-red-500">*</span>
+              </FormLabel>
+              <Input
+                placeholder="제목을 입력하세요"
+                maxLength={10}
+                {...field}
+                className="input-text"
+                disabled={isSubmittingForm}
+              />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {placeInfo && (
+          <FormField
+            control={form.control}
+            name="place_id"
+            render={({ field }) => (
+              <FormItem className="w-full">
+                <FormLabel className="heading-2">장소</FormLabel>
+                <Input
+                  placeholder="장소를 입력하세요"
+                  {...field}
+                  value={placeInfo.place_name}
+                  disabled
+                />
+              </FormItem>
+            )}
+          />
+        )}
+        <FormField
+          control={form.control}
+          name="content"
+          render={({ field }) => (
+            <FormItem className="w-full">
+              <FormLabel className="heading-2">
+                내용
+                <span className="text-red-500">*</span>
+              </FormLabel>
+              <Textarea
+                placeholder="오늘의 일상을 기록해주세요"
+                maxLength={2200}
+                {...field}
+                className="input-text"
+                disabled={isSubmittingForm}
+              />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="images"
+          render={({ field: { value, onChange } }) => (
+            <FormItem className="w-full">
+              <FormLabel className="heading-2">이미지</FormLabel>
+              <MomentImagesInput
+                images={value}
+                onChange={onChange}
+                disabled={isSubmittingForm}
+              />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </form>
+    </Form>
+  );
+}

--- a/src/features/community/components/moment-form/MomentImagesInput.tsx
+++ b/src/features/community/components/moment-form/MomentImagesInput.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { X } from 'lucide-react';
+import Image from 'next/image';
+import { useRef } from 'react';
+
+import { Button } from '@/shared/components';
+
+interface MomentImagesInputProps {
+  images?: File[];
+  onChange: (files: File[]) => void;
+  maxFiles?: number;
+  disabled?: boolean;
+}
+
+export function MomentImagesInput({
+  images = [],
+  onChange,
+  maxFiles = 3,
+  disabled = false,
+}: MomentImagesInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    if (images.length + files.length > maxFiles) {
+      // TODO: 토스트 메시지로 알림
+      return;
+    }
+    onChange([...images, ...files]);
+  };
+
+  const removeImage = (index: number) => {
+    const newImages = [...images];
+    newImages.splice(index, 1);
+    onChange(newImages);
+  };
+
+  return (
+    <div className="w-full space-y-4">
+      <div className="relative">
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {images.map((image, index) => (
+            <div key={index} className="relative flex-shrink-0">
+              <div className="relative h-24 w-24 overflow-hidden rounded-lg">
+                <Image
+                  src={URL.createObjectURL(image)}
+                  alt={`이미지 ${index + 1}`}
+                  fill
+                  className="object-cover"
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="bg-background absolute -top-2 -right-2 h-6 w-6 rounded-full p-0"
+                onClick={() => removeImage(index)}
+                disabled={disabled}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+          {images.length < maxFiles && (
+            <div
+              className="border-muted flex h-24 w-24 flex-shrink-0 cursor-pointer items-center justify-center rounded-lg border-2 border-dashed"
+              onClick={() => inputRef.current?.click()}
+            >
+              <input
+                ref={inputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                className="hidden"
+                onChange={handleImageChange}
+                disabled={disabled}
+              />
+              <div className="text-muted-foreground text-center text-sm">
+                <p>이미지 추가</p>
+                <p className="text-xs">
+                  ({images.length}/{maxFiles})
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/community/components/moment-form/index.ts
+++ b/src/features/community/components/moment-form/index.ts
@@ -1,0 +1,1 @@
+export * from './MomentForm';

--- a/src/features/community/components/write-moment-fab/WriteMomentFab.tsx
+++ b/src/features/community/components/write-moment-fab/WriteMomentFab.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { ChatPlusInSolid } from 'iconoir-react';
+import { useRouter } from 'next/navigation';
+
+import { Button } from '@/shared/components';
+
+export function WriteMomentFab() {
+  const router = useRouter();
+
+  return (
+    <div className="mobile-width fixed bottom-23 z-20">
+      <div className="flex w-full justify-end">
+        <Button
+          size="icon"
+          className="mr-5 h-14 w-14 rounded-full bg-rose-300 shadow-lg hover:bg-rose-400"
+          onClick={() => {
+            router.push('/moments/new');
+          }}
+        >
+          <ChatPlusInSolid className="size-6" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/community/components/write-moment-fab/index.ts
+++ b/src/features/community/components/write-moment-fab/index.ts
@@ -1,0 +1,1 @@
+export * from './WriteMomentFab';

--- a/src/features/community/schemas/index.ts
+++ b/src/features/community/schemas/index.ts
@@ -1,0 +1,1 @@
+export * from './moment';

--- a/src/features/community/schemas/moment.ts
+++ b/src/features/community/schemas/moment.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const momentSchema = z.object({
+  title: z
+    .string()
+    .min(2, '2자 이상 입력해주세요')
+    .max(50, '50자 이하로 입력해주세요'),
+  content: z
+    .string()
+    .min(1, '1자 이상 입력해주세요')
+    .max(2200, '2200자 이하로 입력해주세요'),
+  place_id: z.string().optional(),
+  place_name: z.string().optional(),
+  images: z.array(z.instanceof(File)).optional(),
+  is_public: z.boolean(),
+});
+
+export type MomentFormValues = z.infer<typeof momentSchema>;

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -13,3 +13,4 @@ export * from './feedback-button';
 export * from './background-panel';
 export * from './full-screen-message';
 export * from './user-avatar';
+export * from './switch';

--- a/src/shared/components/switch/Switch.tsx
+++ b/src/shared/components/switch/Switch.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import * as SwitchPrimitive from '@radix-ui/react-switch';
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+export function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}

--- a/src/shared/components/switch/index.ts
+++ b/src/shared/components/switch/index.ts
@@ -1,0 +1,1 @@
+export * from './Switch';


### PR DESCRIPTION
## 📝 PR 개요
기록 작성 기능 구현 및 UI/UX 개선

## 🔍 변경사항
- 기록 작성 페이지(`/moments/new`) 구현
  - 제목, 내용 입력 폼
  - 이미지 업로드 기능 (최대 3장)
  - 공개/비공개 설정 토글
- UI 컴포넌트 추가
  - `WriteMomentFab`: 기록 작성 플로팅 버튼
  - `HeaderCheckButton`: 헤더 체크 버튼
  - `HeaderVisibilityToggle`: 공개/비공개 토글
- 모바일 환경 고려한 UI/UX 개선
  - 모바일 가로사이즈 글로벌 클래스 정의
  - 반응형 레이아웃 적용
- 데이터 검증 로직 추가
  - Zod 스키마를 통한 입력값 유효성 검사
  - 이미지 업로드 제한 (최대 3장)

## 🔗 관련 이슈
Closes #이슈번호

##  스크린샷

<img width="120" alt="image" src="https://github.com/user-attachments/assets/3bd8d5ad-b7fb-4ef7-b9f8-f32cb120b7f9" />

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/2ba552a8-37f5-42d5-b552-c161946c183b" />


## 🧪 테스트
- [ ] 기록 작성 페이지 접근 및 기본 동작 확인
- [ ] 이미지 업로드 (최대 3장 제한)
- [ ] 공개/비공개 설정 토글 동작
- [ ] 모바일 환경에서 UI 확인

## 🚨 주의사항
- 이미지 업로드 시 메모리 관리 필요
- 모바일 환경에서 키보드 노출 시 UI 조정 필요
- 이미지 업로드 제한(3장) 초과 시 사용자 피드백 필요
- 추후에 API 연결 작업 필요