### PR TITLE
Feat/#139  마이페이지 북마크 장소 리스트 & 기록 리스트 UI 구현 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.1",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.4",
     "@radix-ui/react-slot": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-label": "^2.1.4",
     "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-switch": "^1.2.5",
+    "@radix-ui/react-tabs": "^1.1.12",
     "@tanstack/react-query": "^5.74.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@radix-ui/react-checkbox':
     specifier: ^1.3.1
     version: 1.3.1(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+  '@radix-ui/react-dialog':
+    specifier: ^1.1.14
+    version: 1.1.14(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
   '@radix-ui/react-dropdown-menu':
     specifier: ^2.1.15
     version: 2.1.15(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
@@ -721,6 +724,39 @@ packages:
       '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
       '@radix-ui/react-primitive': 2.1.0(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
       '@radix-ui/react-slot': 1.2.0(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      aria-hidden: 1.2.4
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.6.3(@types/react@19.1.2)(react@19.1.0)
+    dev: false
+
+  /@radix-ui/react-dialog@1.1.14(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
       '@types/react': 19.1.2
       '@types/react-dom': 19.1.2(@types/react@19.1.2)
@@ -4237,7 +4273,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
     dependencies:
-      '@radix-ui/react-dialog': 1.1.11(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   '@radix-ui/react-switch':
     specifier: ^1.2.5
     version: 1.2.5(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+  '@radix-ui/react-tabs':
+    specifier: ^1.1.12
+    version: 1.1.12(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
   '@tanstack/react-query':
     specifier: ^5.74.7
     version: 5.74.7(react@19.1.0)
@@ -1223,6 +1226,33 @@ packages:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.2)(react@19.1.0)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@types/react': 19.1.2
+      '@types/react-dom': 19.1.2(@types/react@19.1.2)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    dev: false
+
+  /@radix-ui/react-tabs@1.1.12(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0):
+    resolution: {integrity: sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.2)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@19.1.2)(@types/react@19.1.2)(react-dom@19.1.0)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.2)(react@19.1.0)
       '@types/react': 19.1.2
       '@types/react-dom': 19.1.2(@types/react@19.1.2)
       react: 19.1.0

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -19,7 +19,7 @@ export default function MainLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div>
+    <div className="relative h-full">
       {children}
       <BottomNavigation />
     </div>

--- a/src/app/(main)/moments/page.tsx
+++ b/src/app/(main)/moments/page.tsx
@@ -6,7 +6,7 @@ import {
 
 export default function Moments() {
   return (
-    <div className="overflow-y-auto pb-22">
+    <div className="h-full overflow-y-auto pb-22">
       <MomentList moments={dummyMomentListData} />
       <WriteMomentFab />
     </div>

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -1,69 +1,26 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-
-import { Profile, useUser } from '@/features/user';
-import { logout } from '@/features/user/api/logout';
-import { Header } from '@/shared/components';
+import { Profile, ProfileSettingsSheet, useUser } from '@/features/user';
+import { FullScreenMessage, Header } from '@/shared/components';
 
 export default function MyPage() {
-  const router = useRouter();
   const { user } = useUser();
 
   if (!user) {
-    return (
-      <div className="flex h-full w-full items-center justify-center">
-        로딩중...
-      </div>
-    );
+    return <FullScreenMessage message="로딩중..." />;
   }
 
   const { username, profile_image, introduction } = user;
 
-  const handleEdit = () => {
-    router.push('/mypage/edit');
-  };
-
-  const handleWithdraw = () => {
-    router.push('/mypage/delete');
-  };
-
-  const handleLogout = async () => {
-    try {
-      await logout();
-      router.push('/onboarding');
-    } catch (error) {
-      console.error('로그아웃 실패:', error);
-    }
-  };
-
   return (
     <>
-      <Header />
+      <Header rightElement={<ProfileSettingsSheet />} />
       <div className="mt-12 flex flex-col items-center px-4">
         <Profile
           username={username}
           profileImage={profile_image ?? ''}
           introduction={introduction ?? ''}
         />
-        <button
-          onClick={handleEdit}
-          className="button-text mb-4 w-1/2 rounded-full bg-rose-100 px-4 py-2 text-gray-800 transition-colors hover:bg-rose-200"
-        >
-          회원정보 수정
-        </button>
-        <button
-          onClick={handleLogout}
-          className="button-text mb-4 w-1/2 rounded-full bg-gray-100 px-4 py-2 text-gray-800 transition-colors hover:bg-gray-200"
-        >
-          로그아웃
-        </button>
-        <button
-          onClick={handleWithdraw}
-          className="text-xs text-gray-400 transition-colors hover:text-gray-600"
-        >
-          회원 탈퇴하기
-        </button>
       </div>
     </>
   );

--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { Profile, ProfileSettingsSheet, useUser } from '@/features/user';
+import { dummyMomentListData, MomentList } from '@/features/community';
+import { dummyPlaceItemData, PlaceList } from '@/features/place';
+import {
+  Profile,
+  ProfileSettingsSheet,
+  ProfileTabs,
+  useUser,
+} from '@/features/user';
 import { FullScreenMessage, Header } from '@/shared/components';
 
 export default function MyPage() {
@@ -11,17 +18,33 @@ export default function MyPage() {
   }
 
   const { username, profile_image, introduction } = user;
+  const moments = dummyMomentListData;
+  const places = dummyPlaceItemData;
 
   return (
-    <>
-      <Header rightElement={<ProfileSettingsSheet />} />
-      <div className="mt-12 flex flex-col items-center px-4">
+    <div className="flex h-full flex-col">
+      <div className="mobile-width z-30 flex w-full flex-shrink-0">
+        <Header rightElement={<ProfileSettingsSheet />} />
+      </div>
+      <main className="flex-grow overflow-y-auto pb-22">
         <Profile
           username={username}
           profileImage={profile_image ?? ''}
           introduction={introduction ?? ''}
         />
-      </div>
-    </>
+        <div className="flex flex-col items-center px-4 pt-4">
+          <ProfileTabs
+            momentContent={
+              moments.length > 0 ? (
+                <MomentList moments={moments} showAuthorInfo={false} />
+              ) : null
+            }
+            bookmarkContent={
+              places.length > 0 ? <PlaceList places={places} /> : null
+            }
+          />
+        </div>
+      </main>
+    </div>
   );
 }

--- a/src/features/community/components/author-info/AuthorInfo.tsx
+++ b/src/features/community/components/author-info/AuthorInfo.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import Link from 'next/link';
+
 import { Author } from '../../types';
 import { formatDateByType } from '../../utils';
 
@@ -16,9 +18,13 @@ export function AuthorInfo({ user, writtenAt }: AuthorInfoProps) {
   return (
     <div className="flex items-center gap-2 text-sm">
       <div className="flex items-center gap-3">
-        <UserAvatar imageUrl={profileImage ?? null} size="small" />
+        <Link href={`/users/${user.id}`}>
+          <UserAvatar imageUrl={profileImage ?? null} size="small" />
+        </Link>
         <div className="flex flex-col">
-          <span className="font-semibold text-gray-700">{nickname}</span>
+          <Link href={`/users/${user.id}`}>
+            <span className="font-semibold text-gray-700">{nickname}</span>
+          </Link>
           <span className="text-gray-500">
             {formatDateByType(writtenAt, 'relative')}
           </span>

--- a/src/features/community/components/moment-list/MomentItem.tsx
+++ b/src/features/community/components/moment-list/MomentItem.tsx
@@ -1,13 +1,16 @@
 import { EyeIcon, MessageCircleIcon, LockIcon } from 'lucide-react';
+import Link from 'next/link';
 
 import { MomentItemType } from '../../types';
+import { formatDateByType } from '../../utils';
 import { AuthorInfo } from '../author-info';
 
 export interface MomentItemProps {
   moment: MomentItemType;
+  showAuthorInfo?: boolean;
 }
 
-export function MomentItem({ moment }: MomentItemProps) {
+export function MomentItem({ moment, showAuthorInfo = true }: MomentItemProps) {
   const {
     author,
     createdAt,
@@ -21,44 +24,53 @@ export function MomentItem({ moment }: MomentItemProps) {
 
   return (
     <div className="relative overflow-hidden rounded-2xl bg-white shadow-md transition-shadow duration-200 hover:shadow-lg">
-      <div className="absolute top-2 right-0 justify-end px-4 py-2">
-        {!isPublic && (
-          <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-500">
-            <LockIcon className="my-1 mr-1 h-4 w-4" />
-            나만보기
-          </span>
-        )}
-      </div>
-      <div className="border-b border-gray-100 px-4 py-3">
-        <AuthorInfo user={author} writtenAt={createdAt} />
-      </div>
-      <div className="flex flex-col gap-3 px-4 py-3">
-        <div className="flex flex-row justify-between gap-2">
-          <div className="flex-1">
-            <h3 className="text-xl font-semibold text-gray-800">{title}</h3>
-            <p className="mt-1 text-sm text-gray-600">{content}</p>
+      {showAuthorInfo && (
+        <>
+          <div className="absolute top-2 right-0 justify-end px-4 py-2">
+            {!isPublic && (
+              <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-500">
+                <LockIcon className="my-1 mr-1 h-4 w-4" />
+                나만보기
+              </span>
+            )}
           </div>
-          {thumbnail && (
-            <div className="h-32 w-32 overflow-hidden rounded-2xl bg-gray-100">
-              <img
-                src={thumbnail}
-                alt={title}
-                className="h-full w-full object-cover"
-              />
+          <div className="border-b border-gray-100 px-4 py-3">
+            <AuthorInfo user={author} writtenAt={createdAt} />
+          </div>
+        </>
+      )}
+      <Link href={`/moments/${moment.id}`}>
+        <div className="flex flex-col gap-3 px-4 py-3">
+          <div className="flex flex-row justify-between gap-2">
+            <div className="flex-1">
+              {!showAuthorInfo && (
+                <div>{formatDateByType(createdAt, 'relative')}</div>
+              )}
+              <h3 className="text-xl font-semibold text-gray-800">{title}</h3>
+              <p className="mt-1 text-sm text-gray-600">{content}</p>
             </div>
-          )}
+            {thumbnail && (
+              <div className="h-32 w-32 overflow-hidden rounded-2xl bg-gray-100">
+                <img
+                  src={thumbnail}
+                  alt={title}
+                  className="h-full w-full object-cover"
+                />
+              </div>
+            )}
+          </div>
         </div>
-      </div>
-      <div className="flex border-t border-gray-100 px-4 py-2 text-sm text-gray-500">
-        <div className="flex flex-1 items-center justify-center gap-1">
-          <MessageCircleIcon className="h-4 w-4" />
-          <span>{commentCount}</span>
+        <div className="flex border-t border-gray-100 px-4 py-2 text-sm text-gray-500">
+          <div className="flex flex-1 items-center justify-center gap-1">
+            <MessageCircleIcon className="h-4 w-4" />
+            <span>{commentCount}</span>
+          </div>
+          <div className="flex flex-1 items-center justify-center gap-1">
+            <EyeIcon className="h-4 w-4" />
+            <span>{viewCount}</span>
+          </div>
         </div>
-        <div className="flex flex-1 items-center justify-center gap-1">
-          <EyeIcon className="h-4 w-4" />
-          <span>{viewCount}</span>
-        </div>
-      </div>
+      </Link>
     </div>
   );
 }

--- a/src/features/community/components/moment-list/MomentList.tsx
+++ b/src/features/community/components/moment-list/MomentList.tsx
@@ -1,20 +1,25 @@
-import Link from 'next/link';
-
 import { MomentItem } from './MomentItem';
 
 import { MomentListType } from '@/features/community/types';
 
 export interface MomentListProps {
   moments: MomentListType;
+  showAuthorInfo?: boolean;
+  emptyContainerClassName?: string;
 }
 
-export function MomentList({ moments }: MomentListProps) {
+export function MomentList({
+  moments,
+  showAuthorInfo = true,
+}: MomentListProps) {
   return (
     <div className="flex flex-col gap-2">
       {moments.map((moment) => (
-        <Link href={`/moments/${moment.id}`} key={moment.id}>
-          <MomentItem moment={moment} key={moment.id} />
-        </Link>
+        <MomentItem
+          moment={moment}
+          key={moment.id}
+          showAuthorInfo={showAuthorInfo}
+        />
       ))}
     </div>
   );

--- a/src/features/place/components/index.ts
+++ b/src/features/place/components/index.ts
@@ -8,3 +8,4 @@ export * from './place-list-bottom-sheet';
 export * from './place-menu';
 export * from './place-open-hours';
 export * from './place-basic-info';
+export * from './place-list';

--- a/src/features/place/components/place-item/PlaceItem.tsx
+++ b/src/features/place/components/place-item/PlaceItem.tsx
@@ -2,26 +2,23 @@
 
 import { useRouter } from 'next/navigation';
 
+import { PlaceItemType } from '../../types';
 import { KeywordList } from '../keyword-list';
 
 export interface PlaceItemProps {
-  id: number;
-  name: string;
-  thumbnail: string;
-  keywords: string[];
+  place: PlaceItemType;
   isClickable?: boolean;
   isDetailButton?: boolean;
 }
 
 export function PlaceItem({
-  id,
-  name,
-  thumbnail,
-  keywords,
+  place,
   isClickable,
   isDetailButton,
 }: PlaceItemProps) {
   const router = useRouter();
+  const { id, name, thumbnail, keywords } = place;
+
   const handleDetailClick = () => {
     router.push(`/places/${id}`);
   };

--- a/src/features/place/components/place-list-bottom-sheet/PlaceListBottomSheet.tsx
+++ b/src/features/place/components/place-list-bottom-sheet/PlaceListBottomSheet.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../hooks';
 import { useBottomSheetStore } from '../../stores';
 import { Place } from '../../types';
-import { PlaceItem } from '../place-item';
+import { PlaceList } from '../place-list';
 
 export interface PlaceListBottomSheetProps {
   places: Place[];
@@ -59,20 +59,7 @@ export function PlaceListBottomSheet({ places }: PlaceListBottomSheetProps) {
             onScroll={handleScroll}
             className="my-10 flex-1 overflow-y-auto px-4 pb-10"
           >
-            <div className="space-y-8">
-              {places.map((place) => (
-                <div key={place.id} className="border-b border-zinc-200 pb-8">
-                  <PlaceItem
-                    key={place.id}
-                    id={place.id}
-                    name={place.name}
-                    thumbnail={place.thumbnail}
-                    keywords={place.keywords}
-                    isClickable
-                  />
-                </div>
-              ))}
-            </div>
+            <PlaceList places={places} />
           </div>
         </Drawer.Content>
       </Drawer.Portal>

--- a/src/features/place/components/place-list/PlaceList.tsx
+++ b/src/features/place/components/place-list/PlaceList.tsx
@@ -1,0 +1,21 @@
+import { PlaceItem } from '../place-item';
+
+import { PlaceListType } from '@/features/place';
+
+export interface PlaceListProps {
+  places: PlaceListType;
+  emptyContainerClassName?: string;
+  emptyMessage?: string;
+}
+
+export function PlaceList({ places }: PlaceListProps) {
+  return (
+    <div className="space-y-8">
+      {places.map((place) => (
+        <div key={place.id} className="border-b border-zinc-200 pb-8">
+          <PlaceItem place={place} isClickable />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/place/components/place-list/index.ts
+++ b/src/features/place/components/place-list/index.ts
@@ -1,0 +1,1 @@
+export * from './PlaceList';

--- a/src/features/place/types/place.ts
+++ b/src/features/place/types/place.ts
@@ -17,6 +17,13 @@ export interface Place {
   location: Location;
 }
 
+export type PlaceListType = PlaceItemType[];
+
+export type PlaceItemType = Pick<
+  Place,
+  'id' | 'name' | 'thumbnail' | 'keywords'
+>;
+
 export interface PlaceDetail {
   id: number;
   name: string;
@@ -51,3 +58,30 @@ export interface Menu {
   name: string;
   price: number | null;
 }
+
+export const dummyPlaceItemData: PlaceListType = [
+  {
+    id: 1548136332,
+    name: 'CU 판교스페이스점',
+    thumbnail: 'https://cdn.dev.dolpin.site/place/1548136332.jpg',
+    keywords: ['편맥 추천', '야외 공간', '경기지역화폐'],
+  },
+  {
+    id: 1797985320,
+    name: 'GS25 판교스페이스점',
+    thumbnail: 'https://cdn.dev.dolpin.site/place/1797985320.jpg',
+    keywords: ['깔끔한 내부', '경기지역화폐'],
+  },
+  {
+    id: 1489570574,
+    name: 'GS25 판교H스퀘어점',
+    thumbnail: 'https://cdn.dev.dolpin.site/place/1489570574.jpg',
+    keywords: ['깔끔함', '경기지역화폐', '친절함'],
+  },
+  {
+    id: 19155729,
+    name: 'GS25 판교삼환점',
+    thumbnail: 'https://cdn.dev.dolpin.site/place/19155729.jpg',
+    keywords: ['포스트박스'],
+  },
+];

--- a/src/features/user/components/index.ts
+++ b/src/features/user/components/index.ts
@@ -3,3 +3,4 @@ export * from './profile-form';
 export * from './delete-account';
 export * from './consent';
 export * from './profile-settings-sheet';
+export * from './profile-tabs';

--- a/src/features/user/components/index.ts
+++ b/src/features/user/components/index.ts
@@ -2,3 +2,4 @@ export * from './profile';
 export * from './profile-form';
 export * from './delete-account';
 export * from './consent';
+export * from './profile-settings-sheet';

--- a/src/features/user/components/profile-settings-sheet/ProfileSettingsSheet.tsx
+++ b/src/features/user/components/profile-settings-sheet/ProfileSettingsSheet.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { LogOut, Menu } from 'iconoir-react';
+import { UserCog, UserX } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { logout } from '../../api';
+
+import {
+  Button,
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/shared/components';
+export function ProfileSettingsSheet() {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+      router.push('/onboarding');
+    } catch (error) {
+      console.error('로그아웃 실패:', error);
+    }
+  };
+
+  const menuItems = [
+    {
+      href: '/mypage/edit',
+      label: '회원정보 수정',
+      icon: <UserCog className="mr-2 h-4 w-4" />,
+    },
+    {
+      href: '/mypage/delete',
+      label: '회원탈퇴',
+      icon: <UserX className="mr-2 h-4 w-4" />,
+    },
+  ];
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="ghost" className="h-12 w-12">
+          <Menu className="size-6" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="rounded-l-2xl">
+        <SheetHeader>
+          <SheetTitle className="text-xl">내 정보</SheetTitle>
+        </SheetHeader>
+        <nav className="mt-4 flex flex-col gap-5 px-8">
+          {menuItems.map((item) => (
+            <Link key={item.href} href={item.href} passHref>
+              <Button
+                variant="ghost"
+                className="w-full justify-start font-light"
+              >
+                {item.icon}
+                {item.label}
+              </Button>
+            </Link>
+          ))}
+        </nav>
+        <SheetFooter className="border-t">
+          <Button
+            variant="ghost"
+            className="w-full justify-start"
+            onClick={handleLogout}
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            로그아웃
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/features/user/components/profile-settings-sheet/index.ts
+++ b/src/features/user/components/profile-settings-sheet/index.ts
@@ -1,0 +1,1 @@
+export * from './ProfileSettingsSheet';

--- a/src/features/user/components/profile-tabs/ProfileTabs.tsx
+++ b/src/features/user/components/profile-tabs/ProfileTabs.tsx
@@ -1,0 +1,65 @@
+import {
+  FullScreenMessage,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/shared/components';
+
+interface TabItem {
+  label: string;
+  value: string;
+  content: React.ReactNode;
+}
+
+export interface ProfileTabsProps {
+  momentContent: React.ReactNode | null;
+  bookmarkContent: React.ReactNode | null;
+}
+
+export function ProfileTabs({
+  momentContent,
+  bookmarkContent,
+}: ProfileTabsProps) {
+  const tabs: TabItem[] = [
+    {
+      label: '내 기록',
+      value: 'logs',
+      content: momentContent ? (
+        momentContent
+      ) : (
+        <FullScreenMessage className="h-52" message="아직 기록이 없어요." />
+      ),
+    },
+    {
+      label: '북마크',
+      value: 'bookmarks',
+      content: bookmarkContent ? (
+        <div className="mt-6">{bookmarkContent}</div>
+      ) : (
+        <FullScreenMessage
+          className="h-52"
+          message="아직 북마크한 장소가 없어요."
+        />
+      ),
+    },
+  ];
+
+  return (
+    <Tabs defaultValue="logs" className="w-full">
+      <TabsList className="w-full">
+        {tabs.map((tab) => (
+          <TabsTrigger key={tab.value} value={tab.value}>
+            {tab.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+
+      {tabs.map((tab) => (
+        <TabsContent key={tab.value} value={tab.value} className="mt-3">
+          {tab.content}
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}

--- a/src/features/user/components/profile-tabs/index.ts
+++ b/src/features/user/components/profile-tabs/index.ts
@@ -1,0 +1,1 @@
+export * from './ProfileTabs';

--- a/src/shared/components/full-screen-message/FullScreenMessage.tsx
+++ b/src/shared/components/full-screen-message/FullScreenMessage.tsx
@@ -1,10 +1,21 @@
+import { cn } from '@/shared/lib/utils';
+
 export interface FullScreenMessageProps {
   message: string;
+  className?: string;
 }
 
-export function FullScreenMessage({ message }: FullScreenMessageProps) {
+export function FullScreenMessage({
+  message,
+  className = '',
+}: FullScreenMessageProps) {
   return (
-    <div className="flex h-full w-full items-center justify-center">
+    <div
+      className={cn(
+        'flex h-full w-full items-center justify-center',
+        className,
+      )}
+    >
       <div className="text-center text-gray-500">{message}</div>
     </div>
   );

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -16,3 +16,4 @@ export * from './user-avatar';
 export * from './switch';
 export * from './dropdown-menu';
 export * from './sheet';
+export * from './tab';

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -15,3 +15,4 @@ export * from './full-screen-message';
 export * from './user-avatar';
 export * from './switch';
 export * from './dropdown-menu';
+export * from './sheet';

--- a/src/shared/components/sheet/Sheet.tsx
+++ b/src/shared/components/sheet/Sheet.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/shared/lib/utils';
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 absolute inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = 'right',
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: 'top' | 'right' | 'bottom' | 'left';
+}) {
+  return (
+    <>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out absolute z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+          side === 'right' &&
+            'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
+          side === 'left' &&
+            'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+          side === 'top' &&
+            'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
+          side === 'bottom' &&
+            'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close className="ring-offset-background data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden disabled:pointer-events-none">
+          <XIcon className="size-6" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn('flex flex-col gap-1.5 p-4', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn('text-foreground font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/src/shared/components/sheet/index.ts
+++ b/src/shared/components/sheet/index.ts
@@ -1,0 +1,1 @@
+export * from './Sheet';

--- a/src/shared/components/tab/Tabs.tsx
+++ b/src/shared/components/tab/Tabs.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '@/shared/lib/utils';
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn('flex flex-col gap-2', className)}
+      {...props}
+    />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn('flex-1 outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/shared/components/tab/index.ts
+++ b/src/shared/components/tab/index.ts
@@ -1,0 +1,1 @@
+export * from './Tabs';


### PR DESCRIPTION
## 📝 PR 개요

사용자가 자신의 활동 내역을 확인할 수 있는 마이페이지를 구현하였습니다. 이를 위해 설정 메뉴(`Sheet`), 탭(`Tabs`) 등 신규 컴포넌트를 추가하고, 기존 장소 리스트 컴포넌트를 재사용 가능하도록 리팩토링하는 작업을 진행했습니다.

## 🔍 변경사항

- **마이페이지 UI 구현 및 기능 적용**
    - `UserMenuSheet` (설정, 로그아웃 등) 및 `ProfileTabs` (내 기록, 북마크) 컴포넌트 적용
    - 더미데이터를 사용하여 마이페이지 화면 구성
- **컴포넌트 리팩토링 및 재사용성 강화**
    - `PlaceList` 컴포넌트를 `PlaceListBottomSheet`에서 분리하여 마이페이지에서도 재사용
    - `FullScreenMessage` 컴포넌트가 `className`을 props로 받도록 개선하여 스타일 유연성 확보
- **페이지 이동 및 인터랙션 추가**
    - 프로필 이미지/이름 클릭 시 해당 유저 프로필 페이지로 이동
    - 기록 아이템 클릭 시 기록 상세 페이지로 이동
- **레이아웃 및 스타일 개선**
    - 메인 레이아웃 및 `moment` 페이지의 높이(`h-full`) 관련 스타일 수정

## 주요 변경사항

- **`UserMenuSheet.tsx`**: `shadcn/ui`의 `Sheet`를 기반으로 '회원 정보 수정', '탈퇴', '로그아웃' 메뉴를 제공하는 컴포넌트를 구현하고 마이페이지에 적용했습니다.
- **`ProfileTabs.tsx`**: `shadcn/ui`의 `Tabs`를 기반으로 '내 기록'과 '북마크'를 전환해서 볼 수 있는 탭 컴포넌트를 구현했습니다.
- **`PlaceList.tsx` (리팩토링)**: 기존 검색 결과 페이지의 `PlaceListBottomSheet`에서 장소 목록 로직을 `PlaceList` 공통 컴포넌트로 분리하여, 마이페이지의 '내 기록' 및 '북마크' 탭에서도 재사용할 수 있도록 구조를 개선했습니다.
- **페이지 이동 로직**: 사용자가 프로필이나 기록을 클릭했을 때, 각각 상세 페이지로 원활하게 이동할 수 있도록 라우팅 기능을 추가했습니다.
- **`FullScreenMessage.tsx` (개선)**: `className`을 props로 전달받아, 사용하는 컨텍스트에 맞게 스타일을 유연하게 덮어쓸 수 있도록 수정했습니다.

## 🔗 관련 이슈

Closes #139 

## 📸 스크린샷 (Optional)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/679b05da-42eb-46f6-bf12-f8bbb4210488" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/97fbc887-8923-432c-8533-2d4794abe3fb" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3124af71-ff54-442b-bbd6-2499ca89ce55" />


## 🧪 테스트 (Optional)

- [ ] 마이페이지에 프로필 정보와 '내 기록'/'북마크' 탭이 정상적으로 표시되는지 확인
- [ ] 우측 상단 메뉴 아이콘 클릭 시 `UserMenuSheet`가 올바르게 나타나는지 확인
- [ ] '내 기록'과 '북마크' 탭 전환이 원활하게 동작하는지 확인
- [ ] 분리된 `PlaceList` 컴포넌트가 마이페이지와 기존 검색 페이지 모두에서 문제없이 렌더링되는지 확인
- [ ] 프로필 이미지/이름 및 기록 아이템 클릭 시 올바른 페이지로 이동하는지 확인

## 🚨 주의사항 (Optional)

- 현재 마이페이지는 더미데이터를 기반으로 구현되어 있으며, 추후 실제 데이터 연동을 위한 API 작업이 필요합니다.
- `PlaceList` 컴포넌트는 재사용성을 위해 분리되었으므로, 관련 수정 시 마이페이지와 검색 페이지의 사이드 이펙트를 함께 고려해야 합니다.
