### PR TITLE
Feat/#93 다른 유저 페이지 구현

### DIFF
--- a/src/app/(main)/(places)/users/[id]/page.tsx
+++ b/src/app/(main)/(places)/users/[id]/page.tsx
@@ -1,0 +1,50 @@
+import { cookies } from 'next/headers';
+
+import { getMoments, MomentList } from '@/features/community';
+import { getUserById, Profile } from '@/features/user';
+import { FullScreenMessage, Header } from '@/shared/components';
+
+export interface ProfilePageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ProfilePage({ params }: ProfilePageProps) {
+  const cookie = (await cookies()).toString();
+  const { id } = await params;
+  const user = await getUserById(Number(id));
+  const moments = await getMoments({
+    limit: 5,
+    cursor: null,
+    type: 'user',
+    userId: Number(id),
+    cookie,
+  });
+
+  if (!user) {
+    return <FullScreenMessage message="로그인이 필요합니다." />;
+  }
+
+  const { username, profile_image, introduction } = user;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="mobile-width z-30 flex w-full flex-shrink-0">
+        <Header showBackButton />
+      </div>
+      <main className="flex-grow overflow-y-auto pb-22">
+        <Profile
+          username={username}
+          profileImage={profile_image ?? ''}
+          introduction={introduction ?? ''}
+        />
+        <div className="px-4 pt-4">
+          <MomentList
+            initialMoments={moments}
+            type="user"
+            userId={Number(id)}
+          />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,6 +78,7 @@ body {
   overflow-x: hidden;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
   transition: max-width 0.3s ease-in-out;
+  word-break: break-all;
 }
 
 .mobile-width {

--- a/src/features/community/components/moment-detail-content/MomentDetailContent.tsx
+++ b/src/features/community/components/moment-detail-content/MomentDetailContent.tsx
@@ -14,7 +14,7 @@ export function MomentDetailContent({
 }: MomentDetailContentProps) {
   return (
     <div className="my-7 flex flex-col gap-2">
-      <div className="break-after-auto text-sm">{content}</div>
+      <div className="text-sm">{content}</div>
       {place && (
         <div className="bg-card mt-4 rounded-lg border p-4">
           <div className="flex items-center gap-2">

--- a/src/features/user/api/getUserById.ts
+++ b/src/features/user/api/getUserById.ts
@@ -1,0 +1,13 @@
+import { User } from '../types';
+
+import { fetchApi } from '@/shared/lib/fetchApi';
+
+export async function getUserById(userId: number): Promise<User> {
+  try {
+    const response = await fetchApi<User>(`/api/v1/users/${userId}`);
+    return response;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}

--- a/src/features/user/api/index.ts
+++ b/src/features/user/api/index.ts
@@ -6,3 +6,4 @@ export * from './signup';
 export * from './logout';
 export * from './deleteUser';
 export * from './getUser';
+export * from './getUserById';

--- a/src/features/user/components/profile/Profile.tsx
+++ b/src/features/user/components/profile/Profile.tsx
@@ -17,7 +17,7 @@ export function Profile({
     <div className="flex flex-col items-center px-4 py-6">
       <UserAvatar imageUrl={profileImage} size="large" />
       <h1 className="heading-2 mt-4 mb-2">{username}</h1>
-      <p className="body-text mb-4 text-center whitespace-pre-line text-gray-600">
+      <p className="body-text mb-4 px-4 text-center break-keep whitespace-pre-line text-gray-600">
         {introduction}
       </p>
     </div>


### PR DESCRIPTION
# ✨ 다른 유저 페이지 구현 및 프로필 스타일 개선

## 📝 PR 개요
다른 유저의 프로필을 조회할 수 있는 페이지를 구현하고, 프로필 텍스트 스타일을 개선했습니다. 
유저 정보 조회 API를 추가하여 다른 유저의 정보를 표시할 수 있도록 했습니다.

## 🔍 변경사항

### 다른 유저 페이지 구현
- `getUserById` API 추가
  - 특정 유저 정보 조회 기능
  - 유저 ID 기반 데이터 fetching
- 다른 유저 페이지 컴포넌트 구현
  - 유저 프로필 정보 표시
  - 유저 관련 데이터 표시

### 스타일 개선
- 프로필 텍스트 스타일 최적화
  - 프로필 텍스트: `break-keep` 적용
  - 나머지 텍스트: `break-all` 적용
  - 텍스트 오버플로우 처리 개선

## 🔗 관련 이슈
- Closes #93 

## 📸 스크린샷
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/cb833677-2ba2-4546-a935-71cccfae5771" />


## 🧪 테스트
- [ ] 다른 유저 페이지 접근 및 정보 표시 확인
- [ ] `getUserById` API 정상 동작 확인
- [ ] 프로필 텍스트 스타일 적용 확인
