### PR TITLE
Feat/#140 장소 북마크 장소 리스트 & 기록 리스트 API 연결

### DIFF
--- a/src/app/(main)/mypage/page.tsx
+++ b/src/app/(main)/mypage/page.tsx
@@ -1,25 +1,34 @@
-'use client';
+import { cookies } from 'next/headers';
 
-import { dummyMomentListData, MomentList } from '@/features/community';
-import { dummyPlaceItemData, PlaceList } from '@/features/place';
+import { getMoments, MomentList } from '@/features/community';
+import { getBookmarks, PlaceList } from '@/features/place';
 import {
+  getUser,
   Profile,
   ProfileSettingsSheet,
   ProfileTabs,
-  useUser,
 } from '@/features/user';
 import { FullScreenMessage, Header } from '@/shared/components';
 
-export default function MyPage() {
-  const { user } = useUser();
+export default async function MyPage() {
+  const cookie = (await cookies()).toString();
+  const user = await getUser(cookie);
 
   if (!user) {
     return <FullScreenMessage message="로딩중..." />;
   }
 
   const { username, profile_image, introduction } = user;
-  const moments = dummyMomentListData;
-  const places = dummyPlaceItemData;
+
+  const moments = await getMoments({
+    limit: 5,
+    cursor: null,
+    type: 'my',
+    cookie,
+  });
+  const { bookmarks } = await getBookmarks({
+    cookie,
+  });
 
   return (
     <div className="flex h-full flex-col">
@@ -35,12 +44,12 @@ export default function MyPage() {
         <div className="flex flex-col items-center px-4 pt-4">
           <ProfileTabs
             momentContent={
-              moments.length > 0 ? (
-                <MomentList moments={moments} showAuthorInfo={false} />
+              moments.items.length > 0 ? (
+                <MomentList initialMoments={moments} type="my" />
               ) : null
             }
             bookmarkContent={
-              places.length > 0 ? <PlaceList places={places} /> : null
+              bookmarks.length > 0 ? <PlaceList places={bookmarks} /> : null
             }
           />
         </div>

--- a/src/features/user/api/getUser.ts
+++ b/src/features/user/api/getUser.ts
@@ -2,9 +2,11 @@ import { User } from '../types';
 
 import { fetchApi } from '@/shared/lib/fetchApi';
 
-export async function getUser(): Promise<User> {
+export async function getUser(cookie?: string): Promise<User> {
   try {
-    const response = await fetchApi<User>('/api/v1/users/me');
+    const response = await fetchApi<User>('/api/v1/users/me', {
+      headers: cookie ? { Cookie: cookie } : undefined,
+    });
     return response;
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## 📝 PR 개요
북마크한 장소와 기록 리스트를 서버 API와 연동하고, 서버 사이드에서의 유저 인증 처리를 개선했습니다.

## 🔍 변경사항

### API 연동 구현
- 북마크 장소 리스트 API 연동
  - 북마크한 장소 목록 조회

- 기록 리스트 API 연동
  - 사용자 기록 목록 조회


### 유저 인증 개선
- `getUser` API 쿠키 기반 인증 구현
  - 서버 사이드 API 호출 시 쿠키 값 활용


## 🔗 관련 이슈
- Closes #140 

## 스크린샷

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/66bd4f11-8830-4bb5-b570-03d17776c03b" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/bab030af-8303-4cbf-9bb1-87f164101562" />



## 🧪 테스트
- [ ] 북마크 장소 리스트 API 정상 동작 확인
  - 북마크 목록 조회
  - 북마크 상태 변경
- [ ] 기록 리스트 API 정상 동작 확인
  - 기록 목록 조회
- [ ] 서버 사이드 API 호출 시 쿠키 인증 확인

## 🚨 주의사항
- 서버 사이드 API 호출 시 쿠키 값이 필요합니다