### PR TITLE
Feat#157 작성,수정,탈퇴 페이지에 히스토리 안남도록 설정

### DIFF
--- a/src/features/community/components/moment-detail-owner-dropdown/MomentDetailOwnerDropdown.tsx
+++ b/src/features/community/components/moment-detail-owner-dropdown/MomentDetailOwnerDropdown.tsx
@@ -25,7 +25,7 @@ export function MomentDetailOwnerDropdown({
   const { showSuccessToast, showErrorToast } = useToast();
 
   const handleEdit = () => {
-    router.push(`/moments/${momentId}/edit`);
+    router.replace(`/moments/${momentId}/edit`);
   };
 
   const handleDelete = async () => {

--- a/src/features/community/components/write-moment-fab/WriteMomentFab.tsx
+++ b/src/features/community/components/write-moment-fab/WriteMomentFab.tsx
@@ -5,7 +5,14 @@ import { useRouter } from 'next/navigation';
 
 import { Button } from '@/shared/components';
 
-export function WriteMomentFab() {
+interface WriteMomentFabProps {
+  place?: {
+    id: number;
+    name: string;
+  };
+}
+
+export function WriteMomentFab({ place }: WriteMomentFabProps) {
   const router = useRouter();
 
   return (
@@ -15,7 +22,11 @@ export function WriteMomentFab() {
           size="icon"
           className="mr-5 h-14 w-14 rounded-full bg-rose-300 shadow-lg hover:bg-rose-400"
           onClick={() => {
-            router.push('/moments/new');
+            router.replace(
+              place
+                ? `/moments/new?placeId=${place.id}&placeName=${place.name}`
+                : '/moments/new',
+            );
           }}
         >
           <ChatPlusInSolid className="size-6" />

--- a/src/features/user/components/profile-settings-sheet/ProfileSettingsSheet.tsx
+++ b/src/features/user/components/profile-settings-sheet/ProfileSettingsSheet.tsx
@@ -54,7 +54,7 @@ export function ProfileSettingsSheet() {
         </SheetHeader>
         <nav className="mt-4 flex flex-col gap-5 px-8">
           {menuItems.map((item) => (
-            <Link key={item.href} href={item.href} passHref>
+            <Link key={item.href} href={item.href} replace>
               <Button
                 variant="ghost"
                 className="w-full justify-start font-light"


### PR DESCRIPTION

## 📝 PR 개요
작성, 수정, 탈퇴 페이지와 같이 히스토리에 남길 필요가 없는 페이지들의 네비게이션을 개선하여 사용자 경험을 향상시켰습니다.

## 🔍 변경사항

### 🔄 네비게이션 방식 변경
- 작성 페이지 (`/moments/new'`) 히스토리 제거
- 수정 페이지 (`/moments/${momentId}/edit`, `/mypage/delete`) 히스토리 제거
- 탈퇴 페이지 (`/mypage/delete`) 히스토리 제거

### 🛠️ 구현 방식
- `Link` 컴포넌트에 `replace` prop 추가
- 프로그래매틱 네비게이션에 `router.replace()` 적용

## 🔗 관련 이슈
Closes #157 

## 🧪 테스트

- [ ] 작성 페이지에서 뒤로가기 시 이전 페이지로 정상 이동 확인
- [ ] 수정 페이지에서 뒤로가기 시 이전 페이지로 정상 이동 확인
- [ ] 탈퇴 페이지에서 뒤로가기 시 이전 페이지로 정상 이동 확인
- [ ] 브라우저 히스토리에 해당 페이지들이 남지 않는지 확인

## 주의사항
- 히스토리가 제거되므로 사용자가 브라우저의 뒤로가기 버튼으로 해당 페이지로 돌아갈 수 없음
- 페이지 새로고침 시에는 히스토리가 남을 수 있음 (브라우저 기본 동작)