### PR TITLE
Feat/#156 장소에 기록 작성 버튼 및 기록 리스트 추가

### DIFF
--- a/src/app/(main)/(places)/places/[id]/page.tsx
+++ b/src/app/(main)/(places)/places/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers';
 
+import { PlaceMomentSection, WriteMomentFab } from '@/features/community';
 import {
   getPlaceDetail,
   PlaceBasicInfo,
@@ -43,8 +44,10 @@ export default async function PlaceDetailPage({
           <PlaceBasicInfo placeBasicInfo={placeBasicInfo} />
           {!isOpenHoursEmpty && <PlaceOpenHours openHours={opening_hours} />}
           {!isMenuEmpty && <PlaceMenu menu={menu} />}
+          <PlaceMomentSection placeId={Number(id)} />
         </div>
       </div>
+      <WriteMomentFab place={place} />
     </div>
   );
 }

--- a/src/features/community/api/getMoments.ts
+++ b/src/features/community/api/getMoments.ts
@@ -8,6 +8,7 @@ interface getMomentsParams {
   type: MomentType;
   userId?: number;
   cookie?: string;
+  placeId?: number;
 }
 
 interface MomentListResponse {
@@ -47,7 +48,7 @@ interface MomentListResponse {
 export async function getMoments(
   params: getMomentsParams,
 ): Promise<MomentListType> {
-  const { limit, cursor, type, userId, cookie } = params;
+  const { limit, cursor, type, userId, cookie, placeId } = params;
   const queryParams = new URLSearchParams({
     limit: String(limit),
   });
@@ -63,6 +64,8 @@ export async function getMoments(
     endpoint = `/api/v1/users/${userId}/moments`;
   } else if (type === 'user' && !userId) {
     throw new Error('userId is required for user moment type');
+  } else if (type === 'place' && placeId) {
+    endpoint = `/api/v1/places/${placeId}/moments`;
   }
 
   try {
@@ -84,7 +87,7 @@ export async function getMoments(
         viewCount: moment.view_count,
         commentCount: moment.comment_count,
         author:
-          type === 'all'
+          type === 'all' || type === 'place'
             ? {
                 id: moment.author.id,
                 nickname: moment.author.nickname,

--- a/src/features/community/components/index.ts
+++ b/src/features/community/components/index.ts
@@ -10,3 +10,4 @@ export * from './comment-list';
 export * from './comment-input';
 export * from './comment-section';
 export * from './moment-detail-owner-dropdown';
+export * from './place-moment-section';

--- a/src/features/community/components/moment-list/MomentList.tsx
+++ b/src/features/community/components/moment-list/MomentList.tsx
@@ -16,9 +16,15 @@ export interface MomentListProps {
   type: MomentType;
   initialMoments: MomentListType;
   userId?: number;
+  placeId?: number;
 }
 
-export function MomentList({ type, initialMoments, userId }: MomentListProps) {
+export function MomentList({
+  type,
+  initialMoments,
+  userId,
+  placeId,
+}: MomentListProps) {
   const { items, isLoading, hasError, targetRef } =
     useInfiniteScroll<MomentItemType>({
       initialData: initialMoments,
@@ -28,6 +34,7 @@ export function MomentList({ type, initialMoments, userId }: MomentListProps) {
           cursor,
           type,
           userId,
+          placeId,
         });
         return newData;
       },

--- a/src/features/community/components/place-moment-section/PlaceMomentSection.tsx
+++ b/src/features/community/components/place-moment-section/PlaceMomentSection.tsx
@@ -1,0 +1,34 @@
+import { getMoments } from '../../api';
+import { INFINITE_SCROLL } from '../../constants';
+import { MomentList } from '../moment-list';
+
+export interface PlaceMomentSectionProps {
+  placeId: number;
+}
+
+export async function PlaceMomentSection({ placeId }: PlaceMomentSectionProps) {
+  const initialMoments = await getMoments({
+    limit: INFINITE_SCROLL.MOMENTS_PER_PAGE,
+    cursor: null,
+    type: 'place',
+    placeId,
+  });
+
+  return (
+    <div className="my-6 w-full">
+      <h2 className="heading-2 mb-4">방문 기록</h2>
+      {initialMoments.items.length > 0 ? (
+        <MomentList
+          type="place"
+          placeId={placeId}
+          initialMoments={initialMoments}
+        />
+      ) : (
+        <div className="my-10 flex h-full flex-col items-center justify-center gap-2">
+          <p className="body-text text-gray-500">기록이 없습니다.</p>
+          <p className="body-text text-gray-500">첫 번째 기록을 남겨보세요!</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/community/components/place-moment-section/index.ts
+++ b/src/features/community/components/place-moment-section/index.ts
@@ -1,0 +1,1 @@
+export * from './PlaceMomentSection';

--- a/src/features/community/types/moment.ts
+++ b/src/features/community/types/moment.ts
@@ -2,7 +2,7 @@ import { InfiniteList } from '@/shared/types';
 
 export type MomentListType = InfiniteList<MomentItemType>;
 
-export type MomentType = 'all' | 'my' | 'user';
+export type MomentType = 'all' | 'my' | 'user' | 'place';
 export interface MomentItemType {
   id: number;
   title: string;


### PR DESCRIPTION
## 📝 PR 개요

장소 상세보기 페이지에 장소별 기록(Moment) 목록을 보여주는 기능을 추가했습니다. 사용자가 특정 장소에서 작성한 기록들을 모아볼 수 있으며, 새로운 기록을 작성할 수 있는 FAB(Floating Action Button)도 추가했습니다.

## 🔍 변경사항

- `PlaceMomentSection` 컴포넌트 구현
  - 장소별 기록 목록을 보여주는 섹션 컴포넌트 추가
  - 장소 ID를 기반으로 해당 장소의 기록들을 조회하여 표시
- `MomentList` 컴포넌트 수정
  - `placeId` props를 받아 장소별 필터링 기능 추가
- 기록 목록 API 수정
  - 장소 타입을 받아 처리할 수 있도록 API 로직 개선
- `WriteMomentFab` 컴포넌트 추가
  - 장소 상세 페이지에서 새로운 기록을 작성할 수 있는 FAB 추가

## 🔗 관련 이슈

Closes #156 

## 📸 스크린샷

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/5c84b6a9-f3c0-40c4-8295-4b8858d4f8c9" />

## 🧪 테스트

- [ ] 장소 상세 페이지에서 기록 목록이 정상적으로 표시되는지 확인
- [ ] 특정 장소의 기록만 필터링되어 보이는지 확인
- [ ] WriteMomentFab을 통해 새로운 기록 작성이 가능한지 확인
- [ ] API 응답이 장소 타입에 따라 올바르게 처리되는지 확인

## 🚨 주의사항

- 장소별 기록 목록 조회 시 페이지네이션 처리가 필요할 수 있습니다
- 기록 작성 시 장소 정보가 자동으로 연동되어야 합니다
- API 응답 시간에 따른 로딩 상태 처리가 필요합니다