### PR TITLE
Feat/#160 기록 상세보기 페이지에서 뒤로가기 눌렀을 때, URL 명시적으로 설정

### DIFF
--- a/src/app/(main)/moments/[id]/edit/page.tsx
+++ b/src/app/(main)/moments/[id]/edit/page.tsx
@@ -80,7 +80,7 @@ export default function EditMomentPage() {
         },
       });
       showSuccessToast('기록이 수정되었습니다.');
-      router.push(`/moments/${id}`);
+      router.replace(`/moments/${id}`);
     } catch (error) {
       console.error(error);
       showErrorToast('기록 수정에 실패했습니다.');
@@ -105,7 +105,6 @@ export default function EditMomentPage() {
             />
             <HeaderCheckButton
               onClick={() => {
-                console.log('requestSubmit');
                 formRef.current?.requestSubmit();
               }}
               disabled={isSubmittingForm}

--- a/src/app/(main)/moments/[id]/page.tsx
+++ b/src/app/(main)/moments/[id]/page.tsx
@@ -1,16 +1,12 @@
 import { cookies } from 'next/headers';
 
 import {
-  AuthorInfo,
-  CommentSection,
   getComments,
   getMomentById,
   INFINITE_SCROLL,
-  MomentDetailContent,
-  MomentDetailOwnerDropdown,
-  MomentImageSlider,
+  MomentDetailClient,
 } from '@/features/community';
-import { FullScreenMessage, Header } from '@/shared/components';
+import { FullScreenMessage } from '@/shared/components';
 
 export interface MomentDetailPageProps {
   params: Promise<{ id: string }>;
@@ -33,24 +29,5 @@ export default async function MomentDetailPage({
     return <FullScreenMessage message="존재하지 않는 기록 id 입니다." />;
   }
 
-  const { author, createdAt, images, content, place, isOwner } = moment;
-
-  return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <div className="mobile-width fixed top-0 z-10 flex">
-        <Header showBackButton />
-      </div>
-      <div id="comment-scroll-container" className="flex-1 overflow-y-scroll">
-        <div className="mx-auto mb-22 p-4 px-7 pt-20">
-          <div className="flex items-center justify-between">
-            <AuthorInfo user={author} writtenAt={createdAt} />
-            {isOwner && <MomentDetailOwnerDropdown momentId={moment.id} />}
-          </div>
-          <MomentImageSlider images={images} />
-          <MomentDetailContent content={content} place={place} />
-          <CommentSection momentId={Number(id)} initialComments={comments} />
-        </div>
-      </div>
-    </div>
-  );
+  return <MomentDetailClient moment={moment} comments={comments} />;
 }

--- a/src/app/(main)/moments/new/page.tsx
+++ b/src/app/(main)/moments/new/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useRef, useState } from 'react';
 
 import {
@@ -15,6 +15,11 @@ import { useImageUpload, useToast } from '@/shared/hooks';
 
 export default function NewMomentPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const placeId = searchParams.get('placeId');
+  const placeName = searchParams.get('placeName');
+
   const { showErrorToast } = useToast();
   const { uploadImage } = useImageUpload();
 
@@ -43,10 +48,12 @@ export default function NewMomentPage() {
 
       const { id } = await postMoment({
         ...data,
+        place_id: placeId ? parseInt(placeId) : undefined,
+        place_name: placeName ?? undefined,
         images: imageUrls,
         is_public: isPublic,
       });
-      router.push(`/moments/${id}`);
+      router.replace(`/moments/${id}`);
     } catch (error) {
       console.error(error);
       showErrorToast('기록 생성에 실패했습니다.');
@@ -76,6 +83,10 @@ export default function NewMomentPage() {
         formRef={formRef}
         isSubmittingForm={isSubmittingForm}
         onSubmit={handleSubmit}
+        defaultValues={{
+          place_id: placeId ? parseInt(placeId) : undefined,
+          place_name: placeName ?? undefined,
+        }}
       />
     </div>
   );

--- a/src/app/(main)/mypage/edit/page.tsx
+++ b/src/app/(main)/mypage/edit/page.tsx
@@ -19,7 +19,7 @@ export default function MyPage() {
       ...data,
     });
 
-    router.push('/mypage');
+    router.replace('/mypage');
   };
 
   return (

--- a/src/features/community/components/index.ts
+++ b/src/features/community/components/index.ts
@@ -11,3 +11,4 @@ export * from './comment-input';
 export * from './comment-section';
 export * from './moment-detail-owner-dropdown';
 export * from './place-moment-section';
+export * from './moment-detail-client';

--- a/src/features/community/components/moment-detail-client/MomentDetailClient.tsx
+++ b/src/features/community/components/moment-detail-client/MomentDetailClient.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { CommentListType, MomentDetail } from '../../types';
+
+import {
+  AuthorInfo,
+  CommentSection,
+  MomentDetailContent,
+  MomentDetailOwnerDropdown,
+  MomentImageSlider,
+} from '@/features/community';
+import { Header } from '@/shared/components';
+import { useNavigationStore } from '@/shared/store';
+
+interface MomentDetailClientProps {
+  moment: MomentDetail;
+  comments: CommentListType;
+}
+
+export function MomentDetailClient({
+  moment,
+  comments,
+}: MomentDetailClientProps) {
+  const router = useRouter();
+  const { previousPath, setPreviousPath } = useNavigationStore();
+
+  const { title, author, createdAt, images, content, place, isOwner } = moment;
+
+  const handleBackClick = () => {
+    if (previousPath) {
+      router.replace(previousPath);
+      setPreviousPath(null);
+    } else {
+      router.back();
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="mobile-width fixed top-0 z-10 flex">
+        <Header showBackButton onBackClick={handleBackClick} />
+      </div>
+      <div id="comment-scroll-container" className="flex-1 overflow-y-scroll">
+        <div className="mx-auto mb-22 p-4 px-7 pt-20">
+          <div className="flex items-center justify-between">
+            <AuthorInfo user={author} writtenAt={createdAt} />
+            {isOwner && <MomentDetailOwnerDropdown momentId={moment.id} />}
+          </div>
+          <h1 className="heading-2 my-4">{title}</h1>
+          <MomentImageSlider images={images} />
+          <MomentDetailContent content={content} place={place} />
+          <CommentSection momentId={moment.id} initialComments={comments} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/community/components/moment-detail-client/index.ts
+++ b/src/features/community/components/moment-detail-client/index.ts
@@ -1,0 +1,1 @@
+export * from './MomentDetailClient';

--- a/src/features/community/components/moment-detail-owner-dropdown/MomentDetailOwnerDropdown.tsx
+++ b/src/features/community/components/moment-detail-owner-dropdown/MomentDetailOwnerDropdown.tsx
@@ -25,14 +25,14 @@ export function MomentDetailOwnerDropdown({
   const { showSuccessToast, showErrorToast } = useToast();
 
   const handleEdit = () => {
-    router.replace(`/moments/${momentId}/edit`);
+    router.push(`/moments/${momentId}/edit`);
   };
 
   const handleDelete = async () => {
     try {
       await deleteMoment(momentId);
       showSuccessToast('기록이 삭제되었습니다.');
-      router.push('/moments');
+      router.replace('/moments');
     } catch (error) {
       console.error(error);
       showErrorToast('기록 삭제에 실패했습니다.');

--- a/src/features/community/components/moment-form/MomentForm.tsx
+++ b/src/features/community/components/moment-form/MomentForm.tsx
@@ -22,10 +22,6 @@ export interface MomentFormProps {
   isSubmittingForm: boolean;
   onSubmit: (data: MomentFormValues) => Promise<void>;
   defaultValues?: Partial<MomentFormValues>;
-  placeInfo?: {
-    place_id: number;
-    place_name: string;
-  };
 }
 
 export function MomentForm({
@@ -33,7 +29,6 @@ export function MomentForm({
   isSubmittingForm,
   onSubmit,
   defaultValues,
-  placeInfo,
 }: MomentFormProps) {
   const form = useForm<MomentFormValues>({
     resolver: zodResolver(momentSchema),
@@ -75,7 +70,7 @@ export function MomentForm({
           )}
         />
 
-        {placeInfo && (
+        {defaultValues?.place_id && (
           <FormField
             control={form.control}
             name="place_id"
@@ -85,7 +80,7 @@ export function MomentForm({
                 <Input
                   placeholder="장소를 입력하세요"
                   {...field}
-                  value={placeInfo.place_name}
+                  value={defaultValues.place_name}
                   disabled
                 />
               </FormItem>

--- a/src/features/community/components/write-moment-fab/WriteMomentFab.tsx
+++ b/src/features/community/components/write-moment-fab/WriteMomentFab.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { ChatPlusInSolid } from 'iconoir-react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 
 import { Button } from '@/shared/components';
+import { useNavigationStore } from '@/shared/store';
 
 interface WriteMomentFabProps {
   place?: {
@@ -14,6 +15,17 @@ interface WriteMomentFabProps {
 
 export function WriteMomentFab({ place }: WriteMomentFabProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const { setPreviousPath } = useNavigationStore();
+
+  const handleClick = () => {
+    setPreviousPath(pathname);
+    router.push(
+      place
+        ? `/moments/new?placeId=${place.id}&placeName=${place.name}`
+        : '/moments/new',
+    );
+  };
 
   return (
     <div className="mobile-width fixed bottom-23 z-20">
@@ -21,13 +33,7 @@ export function WriteMomentFab({ place }: WriteMomentFabProps) {
         <Button
           size="icon"
           className="mr-5 h-14 w-14 rounded-full bg-rose-300 shadow-lg hover:bg-rose-400"
-          onClick={() => {
-            router.replace(
-              place
-                ? `/moments/new?placeId=${place.id}&placeName=${place.name}`
-                : '/moments/new',
-            );
-          }}
+          onClick={handleClick}
         >
           <ChatPlusInSolid className="size-6" />
         </Button>

--- a/src/features/user/components/delete-account/DeleteAccountForm.tsx
+++ b/src/features/user/components/delete-account/DeleteAccountForm.tsx
@@ -14,7 +14,7 @@ export function DeleteAccountForm() {
 
   const handleDelete = async () => {
     await deleteUser();
-    router.push('/onboarding');
+    router.replace('/onboarding');
   };
 
   return (

--- a/src/features/user/components/profile-settings-sheet/ProfileSettingsSheet.tsx
+++ b/src/features/user/components/profile-settings-sheet/ProfileSettingsSheet.tsx
@@ -54,7 +54,7 @@ export function ProfileSettingsSheet() {
         </SheetHeader>
         <nav className="mt-4 flex flex-col gap-5 px-8">
           {menuItems.map((item) => (
-            <Link key={item.href} href={item.href} replace>
+            <Link key={item.href} href={item.href}>
               <Button
                 variant="ghost"
                 className="w-full justify-start font-light"

--- a/src/shared/store/index.ts
+++ b/src/shared/store/index.ts
@@ -1,0 +1,1 @@
+export * from './navigationStore';

--- a/src/shared/store/navigationStore.ts
+++ b/src/shared/store/navigationStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface NavigationState {
+  previousPath: string | null;
+  setPreviousPath: (path: string | null) => void;
+}
+
+export const useNavigationStore = create<NavigationState>((set) => ({
+  previousPath: null,
+  setPreviousPath: (path) => set({ previousPath: path }),
+}));


### PR DESCRIPTION
## 📝 PR 개요

사용자 경험 개선을 위한 네비게이션 로직 개선 했습니다.
뒤로가기 시 사용자가 예상하는 페이지로 이동하도록 개선하고, 기록 작성 시 장소 정보를 자동으로 연동하도록 수정했습니다.

## 🔍 변경사항

- 네비게이션 로직 개선
  - `useNavigationStore` 전역 상태 추가
    - 사용자의 이전 페이지 위치 정보 저장
    - 뒤로가기 시 예상되는 페이지로 이동하도록 개선
  - 클라이언트 컴포넌트로 리팩토링
    - `handleBackClick` 함수 구현을 위한 컴포넌트 구조 변경
  - 히스토리 관리 개선
    - `replace`와 `push` 메서드의 어색한 사용 수정
    - 페이지 이동 시 히스토리 스택 정리

- 기록 작성 기능 개선
  - `MomentForm` 컴포넌트 수정
    - URL 쿼리 파라미터에서 장소 데이터를 받아 처리하도록 변경
  - `WriteMomentFab` 컴포넌트 개선
    - 현재 위치에 따른 적절한 path 값 저장 로직 추가
    - 장소 정보 연동 기능 구현

## 🔗 관련 이슈

Closes #160 


## 🧪 테스트

- [ ] 뒤로가기 시 이전 페이지로 정상적으로 이동하는지 확인
- [ ] 장소 상세 페이지에서 기록 작성 시 장소 정보가 자동으로 연동되는지 확인
- [ ] WriteMomentFab이 현재 위치에 따라 올바른 path로 이동하는지 확인
- [ ] 히스토리 스택이 예상대로 동작하는지 확인
- [ ] 쿼리 파라미터를 통한 장소 데이터 전달이 정상적으로 동작하는지 확인

## 🚨 주의사항

- 히스토리 스택이 깊어질 경우를 대비한 최대 스택 크기 고려 필요
- 클라이언트 컴포넌트로의 전환으로 인한 번들 사이즈 영향 모니터링 필요