### PR TITLE
Style/#168 MomentImageSlide에서 이미지 비율 유지하도록 object-contain 적용

### DIFF
--- a/src/features/community/components/moment-image-slider/MomentImageSlide.tsx
+++ b/src/features/community/components/moment-image-slider/MomentImageSlide.tsx
@@ -4,11 +4,11 @@ interface MomentImageSlideProps {
 
 export function MomentImageSlide({ imageUrl }: MomentImageSlideProps) {
   return (
-    <div className="relative h-92 w-92 overflow-hidden rounded-md bg-gray-200">
+    <div className="relative h-92 w-92 overflow-hidden rounded-md bg-gray-100">
       <img
         src={imageUrl}
         alt="moment image"
-        className="pointer-events-none h-full w-full object-cover"
+        className="pointer-events-none h-full w-full object-contain"
       />
     </div>
   );


### PR DESCRIPTION
## 📝 PR 개요

MomentImageSlide 컴포넌트에서 이미지 표시 방식을 개선하여 이미지 비율을 유지하도록 수정했습니다.

## 🔍 변경사항

- `object-cover`에서 `object-contain`으로 변경하여 이미지가 잘리지 않고 전체가 표시되도록 개선
- 이미지 비율 유지로 더 나은 사용자 경험 제공

## 🔗 관련 이슈

Closes #172 

## 📸 스크린샷 (Optional)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/27aae84e-a482-4428-a6e9-f514eab261d6" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/502d58b5-e750-4fcd-b53d-07899db462ed" />


## 🧪 테스트 (Optional)

- [x] 다양한 비율의 이미지로 테스트
- [x] 이미지가 잘리지 않고 전체가 표시되는지 확인
- [x] 컨테이너 크기 내에서 적절히 표시되는지 확인

## 🚨 주의사항 (Optional)

- 이미지 비율이 컨테이너와 다를 경우 빈 공간이 나타날 수 있습니다