### PR TITLE
Feat/#175 댓글 시스템 대댓글 기능 추가

### DIFF
--- a/src/features/community/api/getComments.ts
+++ b/src/features/community/api/getComments.ts
@@ -17,6 +17,7 @@ interface GetCommentsResponse {
       nickname: string;
       profile_image: string | null;
     };
+    parent_comment_id: number | null;
     content: string;
     created_at: string;
     is_owner: boolean;
@@ -67,6 +68,7 @@ export async function getComments(
           nickname: comment.user.nickname,
           profileImage: comment.user.profile_image,
         },
+        parentCommentId: comment.parent_comment_id,
         content: comment.content,
         createdAt: comment.created_at,
         isOwner: comment.is_owner,

--- a/src/features/community/api/postComment.ts
+++ b/src/features/community/api/postComment.ts
@@ -2,6 +2,7 @@ import { fetchApi } from '@/shared/lib/fetchApi';
 
 interface PostCommentParams {
   momentId: number;
+  parent_comment_id?: number | null;
   content: string;
   cookie?: string;
 }
@@ -13,6 +14,7 @@ interface PostCommentResponse {
     nickname: string;
     profile_image: string | null;
   };
+  parent_comment_id: number | null;
   content: string;
   created_at: string;
   is_owner: boolean;
@@ -23,12 +25,14 @@ export async function postComment(
   params: PostCommentParams,
 ): Promise<PostCommentResponse> {
   try {
-    console.log('params', params);
     const response = await fetchApi<PostCommentResponse>(
       `/api/v1/moments/${params.momentId}/comments`,
       {
         method: 'POST',
-        body: JSON.stringify({ content: params.content }),
+        body: JSON.stringify({
+          content: params.content,
+          parent_comment_id: params.parent_comment_id,
+        }),
         headers: params.cookie ? { Cookie: params.cookie } : undefined,
       },
     );

--- a/src/features/community/components/comment-input/CommentInput.tsx
+++ b/src/features/community/components/comment-input/CommentInput.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { Send } from 'lucide-react';
+import { Send, X } from 'lucide-react';
 import { useState } from 'react';
+
+import { useCommentStore } from '../../stores';
 
 import { Button, Input } from '@/shared/components';
 
@@ -15,9 +17,11 @@ export function CommentInput({
   placeholder = '댓글을 입력하세요...',
 }: CommentInputProps) {
   const [content, setContent] = useState('');
+  const { replyState, cancelReply } = useCommentStore();
 
   const handleSubmit = () => {
     if (!content.trim()) return;
+
     onSubmit(content);
     setContent('');
   };
@@ -31,22 +35,39 @@ export function CommentInput({
   };
 
   return (
-    <div className="bg-background mobile-width fixed bottom-20 left-1/2 z-10 flex -translate-x-1/2 items-center gap-2 border-t p-4 pb-7">
-      <Input
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        className="flex-1"
-      />
-      <Button
-        onClick={handleSubmit}
-        disabled={!content.trim()}
-        size="icon"
-        variant="ghost"
-      >
-        <Send className="h-5 w-5" />
-      </Button>
+    <div className="mobile-width fixed bottom-20 left-1/2 z-10 -translate-x-1/2 bg-white px-4 py-3 pb-7">
+      {replyState.isReplying && (
+        <div className="flex items-center pb-2 pl-2">
+          <p className="text-muted-foreground">
+            {replyState.targetUserNickname}님에게 답글 남기는 중 ...
+          </p>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="rounded-full"
+            onClick={cancelReply}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+      <div className="bg-background flex items-center gap-2">
+        <Input
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="flex-1"
+        />
+        <Button
+          onClick={handleSubmit}
+          disabled={!content.trim()}
+          size="icon"
+          variant="ghost"
+        >
+          <Send className="h-5 w-5" />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/features/community/components/comment-list/CommentItem.tsx
+++ b/src/features/community/components/comment-list/CommentItem.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 
+import { useCommentStore } from '../../stores';
 import { CommentItemType } from '../../types/comments';
 import { formatDateByType } from '../../utils';
 
@@ -12,31 +13,78 @@ import { UserAvatar } from '@/shared/components';
 interface CommentItemProps {
   comment: CommentItemType;
   onDelete: (id: number) => void;
+  isReply?: boolean;
+  replies?: CommentItemType[];
 }
 
-export function CommentItem({ comment, onDelete }: CommentItemProps) {
+export function CommentItem({
+  comment,
+  onDelete,
+  isReply,
+  replies,
+}: CommentItemProps) {
   const { id, user, content, createdAt, isOwner } = comment;
+  const { startReply } = useCommentStore();
   const formattedDate = formatDateByType(createdAt, 'relative');
 
+  const handleReplyClick = () => {
+    startReply(user.id, user.nickname, id);
+  };
+
   return (
-    <div className="flex gap-3 p-4">
-      <Link href={`/users/${user.id}`}>
-        <UserAvatar imageUrl={user.profileImage} size="small" />
-      </Link>
-      <div className="flex-1">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Link href={`/users/${user.id}`}>
-              <span className="font-medium">{user.nickname}</span>
-            </Link>
-            <span className="text-muted-foreground text-sm">
-              {formattedDate}
-            </span>
+    <>
+      <div
+        className={`flex gap-3 p-4 ${isReply ? 'mx-4 mb-2 rounded-lg border-l-2 border-gray-200 bg-gray-50/50' : ''}`}
+      >
+        <Link href={`/users/${user.id}`}>
+          <UserAvatar imageUrl={user.profileImage} size="small" />
+        </Link>
+        <div className="flex-1">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Link href={`/users/${user.id}`}>
+                <span className={`font-medium ${isReply ? 'text-sm' : ''}`}>
+                  {user.nickname}
+                </span>
+              </Link>
+              <span
+                className={`text-muted-foreground ${isReply ? 'text-xs' : 'text-sm'}`}
+              >
+                {formattedDate}
+              </span>
+            </div>
+            {isOwner && <CommentOwnerDropDown onDelete={onDelete} id={id} />}
           </div>
-          {isOwner && <CommentOwnerDropDown onDelete={onDelete} id={id} />}
+          <p
+            className={`mt-1 break-after-auto pr-6 ${isReply ? 'text-sm' : 'text-sm'}`}
+          >
+            {content}
+          </p>
+          {!isReply && (
+            <button
+              className="text-muted-foreground mt-2 cursor-pointer text-xs transition-colors hover:text-gray-700"
+              onClick={handleReplyClick}
+            >
+              답글 달기
+            </button>
+          )}
         </div>
-        <p className="mt-1 break-after-auto pr-6 text-sm">{content}</p>
       </div>
-    </div>
+      {replies && replies.length > 0 && (
+        <div className="relative">
+          <div className="space-y-1 pl-8">
+            {replies.map((reply) => (
+              <div key={reply.id} className="relative">
+                <CommentItem
+                  comment={reply}
+                  onDelete={onDelete}
+                  isReply={true}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/features/community/components/comment-list/CommentList.tsx
+++ b/src/features/community/components/comment-list/CommentList.tsx
@@ -31,10 +31,28 @@ export function CommentList({
     );
   }
 
+  const groupedComments = items.reduce(
+    (acc, comment) => {
+      if (!comment.parentCommentId) {
+        acc.push({
+          ...comment,
+          replies: items.filter((item) => item.parentCommentId === comment.id),
+        });
+      }
+      return acc;
+    },
+    [] as (CommentItemType & { replies: CommentItemType[] })[],
+  );
+
   return (
-    <div className="divide-y">
-      {items.map((comment) => (
-        <CommentItem key={comment.id} comment={comment} onDelete={onDelete} />
+    <div>
+      {groupedComments.map((comment) => (
+        <CommentItem
+          key={comment.id}
+          comment={comment}
+          onDelete={onDelete}
+          replies={comment.replies}
+        />
       ))}
       <div ref={targetRef} />
       {isLoading && <LoadingSpinner className="h-24" />}

--- a/src/features/community/components/moment-detail-client/MomentDetailClient.tsx
+++ b/src/features/community/components/moment-detail-client/MomentDetailClient.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
+import { useCommentStore } from '../../stores';
 import { CommentListType, MomentDetail } from '../../types';
 
 import {
@@ -25,10 +26,13 @@ export function MomentDetailClient({
 }: MomentDetailClientProps) {
   const router = useRouter();
   const { previousPath, setPreviousPath } = useNavigationStore();
+  const { cancelReply } = useCommentStore();
 
   const { title, author, createdAt, images, content, place, isOwner } = moment;
 
   const handleBackClick = () => {
+    cancelReply();
+
     if (previousPath) {
       router.replace(previousPath);
       setPreviousPath(null);

--- a/src/features/community/stores/commentStore.ts
+++ b/src/features/community/stores/commentStore.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+
+interface ReplyState {
+  isReplying: boolean;
+  targetUserId: number | null;
+  targetUserNickname: string | null;
+  parentCommentId: number | null;
+}
+
+interface CommentStore {
+  replyState: ReplyState;
+  startReply: (userId: number, nickname: string, commentId: number) => void;
+  cancelReply: () => void;
+}
+
+export const useCommentStore = create<CommentStore>((set) => ({
+  replyState: {
+    isReplying: false,
+    targetUserId: null,
+    targetUserNickname: null,
+    parentCommentId: null,
+  },
+  startReply: (userId: number, nickname: string, commentId: number) => {
+    set({
+      replyState: {
+        isReplying: true,
+        targetUserId: userId,
+        targetUserNickname: nickname,
+        parentCommentId: commentId,
+      },
+    });
+  },
+
+  cancelReply: () => {
+    set({
+      replyState: {
+        isReplying: false,
+        targetUserId: null,
+        targetUserNickname: null,
+        parentCommentId: null,
+      },
+    });
+  },
+}));

--- a/src/features/community/stores/index.ts
+++ b/src/features/community/stores/index.ts
@@ -1,0 +1,1 @@
+export * from './commentStore';

--- a/src/features/community/types/comments.ts
+++ b/src/features/community/types/comments.ts
@@ -8,6 +8,7 @@ export interface CommentItemType {
   content: string;
   createdAt: string;
   isOwner: boolean;
+  parentCommentId: number | null;
 }
 
 export interface CommentUser {


### PR DESCRIPTION
## 📝 PR 개요

댓글 시스템에 대댓글 기능을 추가하여 사용자가 댓글에 답글을 달 수 있도록 구현했습니다.  

---

## 🔍 변경사항

- 댓글 get, post API에 parent_comment_id 속성 추가
- CommentItemType에 parent_comment_id 속성 추가
- 댓글 시스템에 대댓글 상태 관리 추가
- 댓글 입력창에 답글 모드 UI 추가
- 뒤로가기 시 답글 모드 초기화
- 대댓글 작성 시 실시간 UI 업데이트 및 API 연동
- 대댓글 UI 추가 (계층 구조 표시)

---

## 🔗 관련 이슈

Closes #175 

---

## 📸 스크린샷 (Optional)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/120a9386-d2cc-4d79-b2e3-5f4b4f78f597" />
<img width="531" alt="image" src="https://github.com/user-attachments/assets/5feb05c4-aa41-4c07-a000-3ec0d59d4362" />


---

## 🧪 테스트 (Optional)

- [x] 대댓글 작성 기능 테스트
- [x] 대댓글 UI 계층 구조 표시 확인
- [x] 답글 모드 상태 관리 테스트
- [x] 뒤로가기 시 상태 초기화 확인
- [x] 실시간 UI 업데이트 확인

---

## 🚨 주의사항 (Optional)

- 대댓글은 현재 1단계까지만 지원합니다 (대댓글의 대댓글은 미지원)
- 대댓글 작성 시 부모 댓글 작성자에게 답글을 남기는 형태입니다
- 페이지 이동 시 답글 모드가 자동으로 초기화됩니다