### PR TITLE
Deploy: ValidateService 단계에서 health check 진행하여 배포 성공 여부 판단

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -13,15 +13,15 @@ hooks:
 
   AfterInstall:
     - location: scripts/AfterInstall.sh
-      timeout: 60
+      timeout: 120
       runas: root
 
   ApplicationStart:
     - location: scripts/ApplicationStart.sh
-      timeout: 60
+      timeout: 180
       runas: root
 
   ValidateService:
     - location: scripts/NotifyDiscord.sh
-      timeout: 60
+      timeout: 120
       runas: root

--- a/scripts/NotifyDiscord.sh
+++ b/scripts/NotifyDiscord.sh
@@ -1,6 +1,29 @@
 #!/bin/bash
 set -e
 
+echo "▶ 서비스 헬스체크 수행 시작"
+
+PORT=3000
+HEALTH_ENDPOINT="http://localhost:${PORT}/api/health"
+RETRY_COUNT=15
+SLEEP_DURATION=5
+IS_HEALTHY=false
+
+for ((i=1; i<=RETRY_COUNT; i++)); do
+  echo "▶ [시도 $i/${RETRY_COUNT}] ${HEALTH_ENDPOINT} 요청 중..."
+
+  if curl -sf "$HEALTH_ENDPOINT" > /dev/null; then
+    echo "✅ 헬스체크 성공"
+    IS_HEALTHY=true
+    break
+  fi
+
+  echo "❌ 아직 응답 없음, ${SLEEP_DURATION}초 후 재시도"
+  sleep "$SLEEP_DURATION"
+done
+
+echo "❌ 헬스체크 실패 - CodeDeploy 배포 실패로 간주"
+
 WEBHOOK_URL=$(aws secretsmanager get-secret-value \
   --secret-id codedeploy/discord/webhook \
   --query 'SecretString' --output text)
@@ -14,15 +37,25 @@ DEPLOYMENT_ID="${DEPLOYMENT_ID:-N/A}"
 REGION="ap-northeast-2"
 DEPLOYMENT_URL="https://${REGION}.console.aws.amazon.com/codesuite/codedeploy/deployments/${DEPLOYMENT_ID}?region=${REGION}"
 
-MESSAGE="✅ CodeDeploy 배포 성공
+if [ "$IS_HEALTHY" = true ]; then
+  MESSAGE="✅ CodeDeploy 배포 성공
 - 애플리케이션: $APP_NAME
 - 환경: $ENV_NAME
 - [배포 확인하기]($DEPLOYMENT_URL)"
+  STATUS=0
+else
+  MESSAGE="❌ CodeDeploy 배포 실패 (헬스체크 실패)
+- 애플리케이션: $APP_NAME
+- 환경: $ENV_NAME
+- [배포 확인하기]($DEPLOYMENT_URL)"
+  STATUS=1
+fi
 
-# JSON 변환
 PAYLOAD=$(jq -n --arg content "$MESSAGE" '{content: $content}')
 
 curl -H "Content-Type: application/json" \
      -X POST \
      -d "$PAYLOAD" \
      "$WEBHOOK_URL"
+
+exit $STATUS


### PR DESCRIPTION
## 📝 PR 개요

<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
런타임 환경에서 애플리케이션 컨테이너가 정상 기동되지 않거나, 기동 직후 오류로 인해 반복적으로 재시작되는 경우에도 CodeDeploy는 이를 인식하지 못하고 배포를 성공으로 처리하는 문제가 있었습니다.
이를 해결하기 위해 ValidateService 단계에서 실제 서비스의 커스텀 헬스체크를 수행하도록 추가하였습니다.

## 🔍 변경사항

- ValidateService 단계에 /api/health에 대한 헬스 체크 스크립트 추가
- 헬스체크 실패 시 Discord 알림 발송 및 CodeDeploy 배포 실패 처리
- 헬스체크 성공 시 정상적으로 배포 완료 알림 발송

## 🔗 관련 이슈

<!-- 관련된 이슈 링크 (e.g. Closes #123) -->

## 🚨 주의사항 (Optional)

<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
