### PR TITLE
Style/#186 카카오맵 클러스터 숫자가 많을수록 색상 진해지도록 수정

### DIFF
--- a/src/features/place/utils/map.ts
+++ b/src/features/place/utils/map.ts
@@ -145,12 +145,13 @@ export function createPlaceMarkers(
     minLevel: 2,
     gridSize: 40,
     disableClickZoom: true,
+    calculator: [10, 30, 50],
     styles: [
       {
         width: '50px',
         height: '50px',
         background:
-          'radial-gradient(circle, rgba(249, 206, 206, 0.9) 0%, rgba(249, 206, 206, 0.6) 70%, rgba(249, 206, 206, 0.2) 100%)',
+          'radial-gradient(circle, rgba(249, 231, 231, 0.9) 0%, rgba(249, 231, 231, 0.6) 70%, rgba(249, 231, 231, 0.2) 100%)',
         borderRadius: '50%',
         color: '#8B5A5A',
         textAlign: 'center',
@@ -162,7 +163,8 @@ export function createPlaceMarkers(
         width: '60px',
         height: '60px',
         background:
-          'radial-gradient(circle, rgba(249, 231, 231, 0.9) 0%, rgba(249, 231, 231, 0.6) 70%, rgba(249, 231, 231, 0.2) 100%)',
+          'radial-gradient(circle, rgba(249, 206, 206, 0.9) 0%, rgba(249, 206, 206, 0.6) 70%, rgba(249, 206, 206, 0.2) 100%)',
+
         borderRadius: '50%',
         color: '#8B5A5A',
         textAlign: 'center',


### PR DESCRIPTION

## 📝 PR 개요

카카오맵 클러스터링에서 클러스터에 포함된 마커(숫자)가 많을수록 색상이 더 진하게 보이도록 스타일을 개선했습니다.  
이를 통해 지도에서 데이터 밀집도를 더 직관적으로 파악할 수 있습니다.

## 🔍 변경사항

- 클러스터 스타일 배열의 색상 및 투명도 조정
- 숫자가 많을수록(큰 클러스터일수록) 더 진한 색상 적용

## 🔗 관련 이슈

Closes #186 

## 🧪 테스트 (Optional)

- [ ] 다양한 마커 개수로 클러스터 생성 시 색상 변화 확인
- [ ] 클러스터 클릭 및 확대 시 정상 동작 확인