### PR TITLE
Release: v2.3.1 – KakaoMap cluster color intensity by marker count #187

### DIFF
--- a/src/features/place/utils/map.ts
+++ b/src/features/place/utils/map.ts
@@ -145,12 +145,13 @@ export function createPlaceMarkers(
     minLevel: 2,
     gridSize: 40,
     disableClickZoom: true,
+    calculator: [10, 30, 50],
     styles: [
       {
         width: '50px',
         height: '50px',
         background:
-          'radial-gradient(circle, rgba(249, 206, 206, 0.9) 0%, rgba(249, 206, 206, 0.6) 70%, rgba(249, 206, 206, 0.2) 100%)',
+          'radial-gradient(circle, rgba(249, 231, 231, 0.9) 0%, rgba(249, 231, 231, 0.6) 70%, rgba(249, 231, 231, 0.2) 100%)',
         borderRadius: '50%',
         color: '#8B5A5A',
         textAlign: 'center',
@@ -162,7 +163,8 @@ export function createPlaceMarkers(
         width: '60px',
         height: '60px',
         background:
-          'radial-gradient(circle, rgba(249, 231, 231, 0.9) 0%, rgba(249, 231, 231, 0.6) 70%, rgba(249, 231, 231, 0.2) 100%)',
+          'radial-gradient(circle, rgba(249, 206, 206, 0.9) 0%, rgba(249, 206, 206, 0.6) 70%, rgba(249, 206, 206, 0.2) 100%)',
+
         borderRadius: '50%',
         color: '#8B5A5A',
         textAlign: 'center',


### PR DESCRIPTION

## 📝 PR 개요

v2.3.1 패치는 카카오맵 클러스터링의 시각적 가독성을 개선하기 위한 스타일 업데이트를 포함합니다.  
클러스터에 포함된 마커(숫자)가 많을수록 색상이 더 진하게 표시되어, 지도에서 데이터 밀집도를 더욱 직관적으로 파악할 수 있습니다.

---

## 🔍 변경사항

| 타입   | 커밋 번호 | 주요 변경 내용                                         |
| ------ | -------- | ---------------------------------------------------- |
| Style  | #186     | 카카오맵 클러스터 숫자가 많을수록 색상 진해지도록 수정 |

---

## 🔗 관련 이슈

- closes #186
- closes #187

---

## 🧪 테스트 (Optional)

- [x] 클러스터 숫자에 따라 색상 진해짐 정상 동작 확인
- [x] 다양한 마커 개수로 클러스터 생성 시 색상 변화 확인
- [x] 클러스터 클릭 및 확대 시 정상 동작 확인

---

## 🚨 주의사항 (Optional)

- 클러스터 스타일 변경이 지도 전체 UX에 영향을 줄 수 있으니, 실제 서비스 환경에서 색상 가독성을 꼭 확인해주세요.
- 색상 팔레트는 디자인 가이드에 맞게 추가 조정될 수 있습니다.