### PR TITLE
Feat/#211 로그인 없이도 기록, 장소 검색 이용 할 수 있도록 개선

### DIFF
--- a/src/app/(auth)/oauth/kakao/callback/KakaoCallbackClient.tsx
+++ b/src/app/(auth)/oauth/kakao/callback/KakaoCallbackClient.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 
 import { issueAuthTokens } from '@/features/user';
+import { useUserStore } from '@/shared/store';
 
 export default function KakaoCallbackClient() {
   const router = useRouter();
@@ -11,6 +12,7 @@ export default function KakaoCallbackClient() {
   const code = searchParams.get('code');
   const error = searchParams.get('error');
   const error_description = searchParams.get('error_description');
+  const { setLoggedIn } = useUserStore();
 
   useEffect(() => {
     async function handleCallback() {
@@ -35,6 +37,8 @@ export default function KakaoCallbackClient() {
           return;
         }
 
+        setLoggedIn(true);
+
         if (!response.user.profile_completed) {
           router.push('/auth/consent');
         } else {
@@ -47,7 +51,7 @@ export default function KakaoCallbackClient() {
     }
 
     handleCallback();
-  }, [code, error, error_description, router]);
+  }, [code, error, error_description, router, setLoggedIn]);
 
   return (
     <div

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { Suspense } from 'react';
 
 import {
@@ -20,6 +21,9 @@ export default async function Onboarding() {
             <KakaoLoginButton />
           </Suspense>
         </div>
+        <Link href="/" className="mt-2 text-sm text-gray-500">
+          로그인 없이 시작하기
+        </Link>
       </div>
     </div>
   );

--- a/src/app/(main)/login-required/page.tsx
+++ b/src/app/(main)/login-required/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { ArrowLeft, Lock } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export default function LoginRequiredPage() {
+  const router = useRouter();
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    setIsVisible(true);
+  }, []);
+
+  const handleGoBack = () => {
+    router.back();
+  };
+
+  const handleGoToLogin = () => {
+    router.push('/onboarding');
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 p-4">
+      <div
+        className={`w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-xl transition-all duration-700 ease-out ${
+          isVisible
+            ? 'translate-y-0 scale-100 opacity-100'
+            : 'translate-y-8 scale-95 opacity-0'
+        }`}
+      >
+        <div className="mx-auto mb-6 flex h-16 w-16 animate-pulse items-center justify-center rounded-full bg-red-100">
+          <Lock className="h-8 w-8 text-red-500" />
+        </div>
+        <h1 className="mb-3 text-2xl font-bold text-gray-900">
+          로그인이 필요한 페이지입니다
+        </h1>
+        <p className="mb-8 leading-relaxed text-gray-600">
+          이 페이지를 이용하려면 로그인이 필요합니다.
+          <br />
+          로그인하시면 더 많은 기능을 이용하실 수 있습니다.
+        </p>
+        <div className="space-y-4">
+          <button
+            onClick={handleGoToLogin}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-rose-200 px-6 py-3 font-medium text-gray-700 transition-all duration-200 hover:scale-105 hover:bg-rose-300 hover:shadow-lg"
+          >
+            로그인 하러가기
+          </button>
+          <button
+            onClick={handleGoBack}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-gray-100 px-6 py-3 font-medium text-gray-700 transition-all duration-200 hover:bg-gray-200 hover:shadow-md"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            뒤로가기
+          </button>
+        </div>
+        <div className="mt-6 text-xs text-gray-500">
+          <p className="my-4">
+            로그인하면 다음과 같은 기능을 이용할 수 있습니다:
+          </p>
+          <ul className="mt-2 space-y-2 text-left">
+            <li>• 나만의 추억 작성하기</li>
+            <li>• 맛집 즐겨찾기</li>
+            <li>• 다른 사용자와 소통하기</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/community/components/comment-input/CommentInput.tsx
+++ b/src/features/community/components/comment-input/CommentInput.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { useCommentStore } from '../../stores';
 
 import { Button, Input } from '@/shared/components';
+import { useLoginRequiredAction } from '@/shared/hooks';
 
 interface CommentInputProps {
   onSubmit: (content: string) => void;
@@ -18,12 +19,15 @@ export function CommentInput({
 }: CommentInputProps) {
   const [content, setContent] = useState('');
   const { replyState, cancelReply } = useCommentStore();
+  const loginRequiredAction = useLoginRequiredAction();
 
   const handleSubmit = () => {
     if (!content.trim()) return;
 
-    onSubmit(content);
-    setContent('');
+    loginRequiredAction(async () => {
+      onSubmit(content);
+      setContent('');
+    });
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/features/place/hooks/useBookmark.ts
+++ b/src/features/place/hooks/useBookmark.ts
@@ -4,19 +4,28 @@ import { useState } from 'react';
 
 import { postBookmark } from '../api';
 
+import { useLoginRequiredAction } from '@/shared/hooks';
+import { useUserStore } from '@/shared/store';
+
 interface UseBookmarkProps {
   initialIsBookmarked: boolean;
 }
 
 export function useBookmark({ initialIsBookmarked }: UseBookmarkProps) {
-  const [isBookmarked, setIsBookmarked] = useState(initialIsBookmarked);
+  const { isLoggedIn } = useUserStore();
+  const [isBookmarked, setIsBookmarked] = useState(
+    isLoggedIn ? initialIsBookmarked : false,
+  );
   const [isLoading, setIsLoading] = useState(false);
+  const loginRequiredAction = useLoginRequiredAction();
 
   const toggleBookmark = async (placeId: number) => {
-    setIsLoading(true);
-    const response = await postBookmark(placeId);
-    setIsBookmarked(response.is_bookmarked);
-    setIsLoading(false);
+    await loginRequiredAction(async () => {
+      setIsLoading(true);
+      const response = await postBookmark(placeId);
+      setIsBookmarked(response.is_bookmarked);
+      setIsLoading(false);
+    });
   };
 
   return { isBookmarked, isLoading, toggleBookmark };

--- a/src/features/user/components/profile-settings-sheet/ProfileSettingsSheet.tsx
+++ b/src/features/user/components/profile-settings-sheet/ProfileSettingsSheet.tsx
@@ -16,13 +16,17 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/shared/components';
+import { useUserStore } from '@/shared/store';
+
 export function ProfileSettingsSheet() {
   const router = useRouter();
+  const { setLoggedIn } = useUserStore();
 
   const handleLogout = async () => {
     try {
       await logout();
       router.push('/onboarding');
+      setLoggedIn(false);
     } catch (error) {
       console.error('로그아웃 실패:', error);
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,27 +1,40 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-type Routes = Record<string, boolean>;
+const exactPublicPaths = [
+  '/',
+  '/onboarding',
+  '/login-required',
+  '/oauth/kakao/callback',
+  '/moments',
+  '/search',
+  '/users',
+];
 
-const publicOnlyUrls: Routes = {
-  '/onboarding': true,
-  '/oauth/kakao/callback': true,
-};
+const dynamicPublicPatterns = [
+  /^\/moments\/\d+$/,
+  /^\/places\/\d+$/,
+  /^\/users\/\d+$/,
+];
+
+function isPublicPath(pathname: string): boolean {
+  if (exactPublicPaths.includes(pathname)) {
+    return true;
+  }
+
+  return dynamicPublicPatterns.some((pattern) => pattern.test(pathname));
+}
 
 export async function middleware(request: NextRequest) {
   const accessToken = request.cookies.get('access_token')?.value;
-  const exists = publicOnlyUrls[request.nextUrl.pathname];
+  const pathname = request.nextUrl.pathname;
+  const isPublic = isPublicPath(pathname);
 
   console.log('accessToken 확인', accessToken);
-  console.log('exists 확인', exists);
+  console.log('pathname 확인', pathname);
+  console.log('isPublic 확인', isPublic);
 
-  if (!accessToken) {
-    if (!exists) {
-      return NextResponse.redirect(new URL('/onboarding', request.url));
-    }
-  } else {
-    if (exists) {
-      return NextResponse.redirect(new URL('/', request.url));
-    }
+  if (!accessToken && !isPublic) {
+    return NextResponse.redirect(new URL('/login-required', request.url));
   }
 
   return NextResponse.next();

--- a/src/shared/components/global-confirm-dialog/GlobalConfirmDialog.tsx
+++ b/src/shared/components/global-confirm-dialog/GlobalConfirmDialog.tsx
@@ -79,8 +79,9 @@ export function GlobalConfirmDialog() {
           </button>
           <button
             onClick={handleConfirm}
-            className={`rounded-md px-4 py-2 text-sm font-medium text-white focus:ring-2 focus:ring-blue-500 focus:outline-none ${
-              confirmButtonClassName || 'bg-blue-600 hover:bg-blue-700'
+            className={`rounded-md px-4 py-2 text-sm font-medium focus:ring-2 focus:ring-blue-500 focus:outline-none ${
+              confirmButtonClassName ||
+              'bg-blue-600 text-white hover:bg-blue-700'
             }`}
           >
             {confirmText}

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './useImageUpload';
 export * from './useImageInput';
 export * from './useToast';
 export * from './useScrollRestoration';
+export * from './useLoginRequiredAction';

--- a/src/shared/hooks/useLoginRequiredAction.ts
+++ b/src/shared/hooks/useLoginRequiredAction.ts
@@ -1,0 +1,25 @@
+import { useConfirmDialogStore, useUserStore } from '../store';
+
+export function useLoginRequiredAction() {
+  const { isLoggedIn } = useUserStore();
+  const openDialog = useConfirmDialogStore((s) => s.openDialog);
+
+  return async (callback: () => void) => {
+    if (!isLoggedIn) {
+      const shouldLogin = await openDialog({
+        title: '로그인이 필요합니다',
+        description: '이 기능을 사용하려면 로그인이 필요합니다.',
+        confirmText: '로그인하러가기',
+        cancelText: '취소',
+        confirmButtonClassName: 'bg-rose-400 hover:bg-rose-500 text-white',
+      });
+
+      if (shouldLogin) {
+        window.location.href = '/onboarding';
+      }
+      return;
+    }
+
+    callback();
+  };
+}

--- a/src/shared/store/index.ts
+++ b/src/shared/store/index.ts
@@ -1,2 +1,3 @@
 export * from './navigationStore';
 export * from './confirmDialogStore';
+export * from './userStore';

--- a/src/shared/store/userStore.ts
+++ b/src/shared/store/userStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface UserState {
+  isLoggedIn: boolean;
+  setLoggedIn: (loggedIn: boolean) => void;
+}
+
+export const useUserStore = create<UserState>((set) => ({
+  isLoggedIn: false,
+  setLoggedIn: (loggedIn: boolean) => {
+    set({
+      isLoggedIn: loggedIn,
+    });
+  },
+}));


### PR DESCRIPTION
## 📝 PR 개요

사용자 인증 기록, 장소 도메인에서 로그인이 가능하도록 개선했습니다.

## 🔍 변경사항

- **미들웨어 구현**: 로그인이 필요한 페이지 접속 시 자동으로 로그인 요구 페이지로 리다이렉트
- **로그인 요구 페이지**: 사용자 친화적인 로그인 안내 페이지 구현
- **인증 필요 기능 개선**: 
  - 댓글 작성 버튼 클릭 시 로그인 안내창 표시
  - 북마크 버튼 클릭 시 로그인 안내창 표시
- **로그인 상태 관리**: 로그인/로그아웃 시 전역 상태 자동 업데이트
- **온보딩 페이지 개선**: 로그인 없이 시작하기 버튼 추가로 사용자 진입 장벽 완화
- **UI 컴포넌트 개선**: GlobalConfirmDialog의 글씨 색상을 선택적으로 변경 가능하도록 개선
- **커스텀 훅 구현**: `useLoginRequiredAction` 훅으로 인증 필요 액션 로직 재사용 가능
- **전역 상태 관리**: `useUserStore` 추가로 사용자 상태 전역 관리

## 관련 이슈

Closes #211 

## 📸 스크린샷 (Optional)

<img width="1920" height="991" alt="스크린샷 2025-07-24 오후 1 41 21" src="https://github.com/user-attachments/assets/01d505bb-4ef8-4ce3-886c-c8724b19babc" />

<img width="1920" height="992" alt="스크린샷 2025-07-24 오후 1 42 14" src="https://github.com/user-attachments/assets/bcfb65bf-1885-47e6-98a6-0f6176b5cdde" />



<!-- UI 변경사항이 많으므로 주요 변경사항 스크린샷 추가 권장 -->
- 로그인 요구 페이지 UI
- 댓글/북마크 버튼 클릭 시 로그인 안내창
- 온보딩 페이지 로그인 없이 시작하기 버튼
- GlobalConfirmDialog 스타일 변경 결과

## 🧪 테스트 (Optional)

- [ ] 로그인하지 않은 사용자가 보호된 페이지 접속 시 로그인 요구 페이지로 리다이렉트되는지 확인
- [ ] 댓글 작성 버튼 클릭 시 로그인 안내창이 정상적으로 표시되는지 확인
- [ ] 북마크 버튼 클릭 시 로그인 안내창이 정상적으로 표시되는지 확인
- [ ] 로그인/로그아웃 시 전역 상태가 올바르게 업데이트되는지 확인
- [ ] 온보딩 페이지에서 "로그인 없이 시작하기" 버튼이 정상 작동하는지 확인
- [ ] GlobalConfirmDialog의 글씨 색상 변경이 올바르게 적용되는지 확인
- [ ] useLoginRequiredAction 훅이 다양한 컴포넌트에서 재사용 가능한지 확인
- [ ] useUserStore가 전역적으로 사용자 상태를 올바르게 관리하는지 확인

## 주의사항 (Optional)

- 미들웨어 설정이 모든 보호된 라우트에 올바르게 적용되었는지 확인이 필요합니다
- 로그인 상태 변경 시 다른 컴포넌트들의 상태 동기화가 정상적으로 이루어지는지 검증이 필요합니다
- 로그인 없이 시작하기 기능이 기존 로그인 플로우와 충돌하지 않는지 확인이 필요합니다
- 전역 상태 관리 변경으로 인한 성능 영향이 없는지 모니터링이 필요합니다